### PR TITLE
chore: upgrade React to 19.1.0 with related dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
 		"@remix-run/react": "^2.16.5",
 		"@remix-run/server-runtime": "^2.16.5",
 		"isbot": "^4.4.0",
-		"react": "^18.3.1",
-		"react-dom": "^18.3.1"
+		"react": "^19.1.0",
+		"react-dom": "^19.1.0"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20250415.0",
@@ -30,8 +30,8 @@
 		"@eslint/eslintrc": "^3.3.1",
 		"@eslint/js": "^9.24.0",
 		"@remix-run/dev": "^2.16.5",
-		"@types/react": "^18.3.20",
-		"@types/react-dom": "^18.3.6",
+		"@types/react": "^19.1.0",
+		"@types/react-dom": "^19.1.0",
 		"@typescript-eslint/eslint-plugin": "^8.30.1",
 		"@typescript-eslint/parser": "^8.30.1",
 		"autoprefixer": "^10.4.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         version: 2.16.5(@cloudflare/workers-types@4.20250415.0)(typescript@5.8.3)
       "@remix-run/react":
         specifier: ^2.16.5
-        version: 2.16.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+        version: 2.16.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)
       "@remix-run/server-runtime":
         specifier: ^2.16.5
         version: 2.16.5(typescript@5.8.3)
@@ -20,11 +20,11 @@ importers:
         specifier: ^4.4.0
         version: 4.4.0
       react:
-        specifier: ^18.3.1
-        version: 18.3.1
+        specifier: ^19.1.0
+        version: 19.1.0
       react-dom:
-        specifier: ^18.3.1
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.1.0
+        version: 19.1.0(react@19.1.0)
     devDependencies:
       "@cloudflare/workers-types":
         specifier: ^4.20250415.0
@@ -40,13 +40,13 @@ importers:
         version: 9.24.0
       "@remix-run/dev":
         specifier: ^2.16.5
-        version: 2.16.5(@remix-run/react@2.16.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(@types/node@22.14.1)(jiti@1.21.7)(typescript@5.8.3)(vite@6.2.6(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1))(wrangler@4.11.0(@cloudflare/workers-types@4.20250415.0))(yaml@2.7.1)
+        version: 2.16.5(@remix-run/react@2.16.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(@types/node@22.14.1)(jiti@1.21.7)(typescript@5.8.3)(vite@6.2.6(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1))(wrangler@4.11.0(@cloudflare/workers-types@4.20250415.0))(yaml@2.7.1)
       "@types/react":
-        specifier: ^18.3.20
-        version: 18.3.20
+        specifier: ^19.1.0
+        version: 19.1.2
       "@types/react-dom":
-        specifier: ^18.3.6
-        version: 18.3.6(@types/react@18.3.20)
+        specifier: ^19.1.0
+        version: 19.1.2(@types/react@19.1.2)
       "@typescript-eslint/eslint-plugin":
         specifier: ^8.30.1
         version: 8.30.1(@typescript-eslint/parser@8.30.1(eslint@9.24.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.24.0(jiti@1.21.7))(typescript@5.8.3)
@@ -1837,24 +1837,18 @@ packages:
         integrity: sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==,
       }
 
-  "@types/prop-types@15.7.14":
+  "@types/react-dom@19.1.2":
     resolution:
       {
-        integrity: sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==,
-      }
-
-  "@types/react-dom@18.3.6":
-    resolution:
-      {
-        integrity: sha512-nf22//wEbKXusP6E9pfOCDwFdHAX4u172eaJI4YkDRQEZiorm6KfYnSC2SWLDMVWUOWPERmJnN0ujeAfTBLvrw==,
+        integrity: sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw==,
       }
     peerDependencies:
-      "@types/react": ^18.0.0
+      "@types/react": ^19.0.0
 
-  "@types/react@18.3.20":
+  "@types/react@19.1.2":
     resolution:
       {
-        integrity: sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==,
+        integrity: sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==,
       }
 
   "@types/unist@2.0.11":
@@ -5677,13 +5671,13 @@ packages:
       }
     engines: { node: ">= 0.8" }
 
-  react-dom@18.3.1:
+  react-dom@19.1.0:
     resolution:
       {
-        integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==,
+        integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==,
       }
     peerDependencies:
-      react: ^18.3.1
+      react: ^19.1.0
 
   react-is@16.13.1:
     resolution:
@@ -5717,10 +5711,10 @@ packages:
     peerDependencies:
       react: ">=16.8"
 
-  react@18.3.1:
+  react@19.1.0:
     resolution:
       {
-        integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==,
+        integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==,
       }
     engines: { node: ">=0.10.0" }
 
@@ -5936,10 +5930,10 @@ packages:
         integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
       }
 
-  scheduler@0.23.2:
+  scheduler@0.26.0:
     resolution:
       {
-        integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==,
+        integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==,
       }
 
   semver@6.3.1:
@@ -7780,7 +7774,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  "@remix-run/dev@2.16.5(@remix-run/react@2.16.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(@types/node@22.14.1)(jiti@1.21.7)(typescript@5.8.3)(vite@6.2.6(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1))(wrangler@4.11.0(@cloudflare/workers-types@4.20250415.0))(yaml@2.7.1)":
+  "@remix-run/dev@2.16.5(@remix-run/react@2.16.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(@types/node@22.14.1)(jiti@1.21.7)(typescript@5.8.3)(vite@6.2.6(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1))(wrangler@4.11.0(@cloudflare/workers-types@4.20250415.0))(yaml@2.7.1)":
     dependencies:
       "@babel/core": 7.26.10
       "@babel/generator": 7.27.0
@@ -7793,7 +7787,7 @@ snapshots:
       "@mdx-js/mdx": 2.3.0
       "@npmcli/package-json": 4.0.1
       "@remix-run/node": 2.16.5(typescript@5.8.3)
-      "@remix-run/react": 2.16.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      "@remix-run/react": 2.16.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)
       "@remix-run/router": 1.23.0
       "@remix-run/server-runtime": 2.16.5(typescript@5.8.3)
       "@types/mdx": 2.0.13
@@ -7874,14 +7868,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  "@remix-run/react@2.16.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)":
+  "@remix-run/react@2.16.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)":
     dependencies:
       "@remix-run/router": 1.23.0
       "@remix-run/server-runtime": 2.16.5(typescript@5.8.3)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.30.0(react@18.3.1)
-      react-router-dom: 6.30.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-router: 6.30.0(react@19.1.0)
+      react-router-dom: 6.30.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       turbo-stream: 2.4.0
     optionalDependencies:
       typescript: 5.8.3
@@ -8031,15 +8025,12 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  "@types/prop-types@15.7.14": {}
-
-  "@types/react-dom@18.3.6(@types/react@18.3.20)":
+  "@types/react-dom@19.1.2(@types/react@19.1.2)":
     dependencies:
-      "@types/react": 18.3.20
+      "@types/react": 19.1.2
 
-  "@types/react@18.3.20":
+  "@types/react@19.1.2":
     dependencies:
-      "@types/prop-types": 15.7.14
       csstype: 3.1.3
 
   "@types/unist@2.0.11": {}
@@ -10638,31 +10629,28 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
-  react-dom@18.3.1(react@18.3.1):
+  react-dom@19.1.0(react@19.1.0):
     dependencies:
-      loose-envify: 1.4.0
-      react: 18.3.1
-      scheduler: 0.23.2
+      react: 19.1.0
+      scheduler: 0.26.0
 
   react-is@16.13.1: {}
 
   react-refresh@0.14.2: {}
 
-  react-router-dom@6.30.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router-dom@6.30.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       "@remix-run/router": 1.23.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.30.0(react@18.3.1)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-router: 6.30.0(react@19.1.0)
 
-  react-router@6.30.0(react@18.3.1):
+  react-router@6.30.0(react@19.1.0):
     dependencies:
       "@remix-run/router": 1.23.0
-      react: 18.3.1
+      react: 19.1.0
 
-  react@18.3.1:
-    dependencies:
-      loose-envify: 1.4.0
+  react@19.1.0: {}
 
   read-cache@1.0.0:
     dependencies:
@@ -10841,9 +10829,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  scheduler@0.23.2:
-    dependencies:
-      loose-envify: 1.4.0
+  scheduler@0.26.0: {}
 
   semver@6.3.1: {}
 


### PR DESCRIPTION
- Update react and react-dom to 19.1.0
- Update @types/react and @types/react-dom to 19.1.0