### PR TITLE
feat: hide bitcoin wallet on load

### DIFF
--- a/app/components/Wallet/XverseWallet/useWallet.tsx
+++ b/app/components/Wallet/XverseWallet/useWallet.tsx
@@ -16,10 +16,11 @@ import { ByieldWallet } from "~/types";
 
 export const useXverseConnect = () => {
 	const { toast } = useToast();
-	const { handleWalletConnect } = useContext(WalletContext);
+	const { handleWalletConnect, toggleBitcoinModal } = useContext(WalletContext);
 
 	const connectWallet = useCallback(async () => {
 		try {
+			toggleBitcoinModal(true);
 			const response = await Wallet.request(connectMethodName, {
 				permissions: [
 					{

--- a/app/providers/ByieldWalletProvider.tsx
+++ b/app/providers/ByieldWalletProvider.tsx
@@ -9,34 +9,66 @@ interface WalletContextI {
 	isLoading: boolean;
 	connectedWallet: WalletType;
 	handleWalletConnect: (walletToBeConnected: WalletType) => void;
+	toggleBitcoinModal: (show: boolean) => void;
 }
 
 export const WalletContext = createContext<WalletContextI>({
 	isLoading: false,
 	connectedWallet: null,
 	handleWalletConnect: () => {},
+	toggleBitcoinModal: () => {},
 });
 
 export const ByieldWalletProvider = ({ children }: { children: ReactNode }) => {
 	const [isLoading, setIsLoading] = useState<boolean>(true);
 	const [connectedWallet, setConnectedWallet] = useState<WalletType>();
+	const [isModalHidden, setIsModalHidden] = useState<boolean>(true); // State to control modal visibility
 	const currentAccount = useCurrentAccount();
-	// check if SUI connection is active
-	const isSuiWalletActive = currentAccount !== null;
-	// check if bitcoin wallet is active
+	const isSuiWalletActive = !!currentAccount;
 	const { currentAddress } = useXverseAddress();
-	const isBitcoinWalletActive = currentAddress !== null;
+	const isBitcoinWalletActive = !!currentAddress;
 
 	useEffect(() => {
 		setIsLoading(() => true);
+
+		// Function to update bitcoin modal visibility
+		const updateModalVisibility = () => {
+			const modal = document.getElementById("sats-connect-wallet-provider-selector");
+			if (modal) {
+				modal.style.display = isModalHidden ? "none" : "block";
+			}
+		};
+
+		// Run immediately to set initial modal state
+		updateModalVisibility();
+
+		// Set up MutationObserver to watch for modal being added dynamically
+		const observer = new MutationObserver(() => {
+			updateModalVisibility();
+		});
+
+		observer.observe(document.body, { childList: true, subtree: true });
+
+		// Update wallet state
 		setConnectedWallet(() =>
 			isSuiWalletActive ? ByieldWallet.SuiWallet : isBitcoinWalletActive ? ByieldWallet.Xverse : null,
 		);
 		setIsLoading(() => false);
-	}, [isBitcoinWalletActive, isSuiWalletActive]);
+
+		// Cleanup observer on component unmount
+		return () => observer.disconnect();
+	}, [isBitcoinWalletActive, isSuiWalletActive, isModalHidden]);
 
 	const handleWalletConnect = async (walletToBeConnected: WalletType): Promise<void> => {
 		setConnectedWallet(walletToBeConnected);
+		// hide the bitcoin wallet from document DOM
+		if (walletToBeConnected === ByieldWallet.Xverse) {
+			setIsModalHidden(false);
+		}
+	};
+
+	const toggleBitcoinModal = (show: boolean) => {
+		setIsModalHidden(!show);
 	};
 
 	return (
@@ -45,8 +77,16 @@ export const ByieldWalletProvider = ({ children }: { children: ReactNode }) => {
 				isLoading,
 				connectedWallet,
 				handleWalletConnect,
+				toggleBitcoinModal,
 			}}
 		>
+			<style>
+				{`
+          #sats-connect-wallet-provider-selector {
+            display: ${isModalHidden ? "none !important" : "block"};
+          }
+        `}
+			</style>
 			{children}
 		</WalletContext.Provider>
 	);


### PR DESCRIPTION
hide bitcoin wallet on load. we should show it when bitcoin connect button is pressed.

## Summary by Sourcery

Hide the Bitcoin wallet modal on initial load and only display it when the user initiates a Bitcoin connection by leveraging context‐driven state, inline styling, and a MutationObserver.

New Features:
- Hide Bitcoin wallet modal by default and reveal it when the connect button is pressed.

Enhancements:
- Add isModalHidden state and toggleBitcoinModal method in WalletContext for modal visibility control.
- Use a MutationObserver and inline CSS to dynamically hide or show the Bitcoin wallet selector element.
- Invoke toggleBitcoinModal in the Xverse connection hook to display the modal before initiating connection.