### PR TITLE
fix: UI prod issue

### DIFF
--- a/app/components/BuyNBTC/BuyNBTC.tsx
+++ b/app/components/BuyNBTC/BuyNBTC.tsx
@@ -10,7 +10,7 @@ import { useNetworkVariables } from "~/networkConfig";
 import { createBuyNBTCTxn } from "~/util/util";
 import { BUY_NBTC_GAS_FEE_IN_SUI } from "~/constant";
 import { ArrowDown } from "lucide-react";
-import { formatSUI, parseSUI } from "~/lib/denoms";
+import { formatSUI, parseSUI, SUI } from "~/lib/denoms";
 import { useToast } from "~/hooks/use-toast";
 import { useNBTCBalance } from "../Wallet/SuiWallet/useNBTCBalance";
 import { NBTCBalance } from "./NBTCBalance";
@@ -187,6 +187,7 @@ export function BuyNBTC() {
 							placeholder="Enter SUI amount"
 							className="h-24"
 							inputMode="decimal"
+							decimalScale={SUI}
 							allowNegative={false}
 							createEmptySpace
 							rightAdornments={

--- a/app/lib/denoms.ts
+++ b/app/lib/denoms.ts
@@ -4,7 +4,7 @@ import { parseUnits, formatUnits } from "@ethersproject/units";
 
 export const BTC = 8; // BTC -> sats decimals
 export const SUI = 9; // SUI -> mist decimals
-export const NBTC = 9; // NBTC decimals
+export const NBTC = 8; // NBTC decimals
 export const USDC = 6;
 
 export function parse(amount: string, decimals: number): bigint {


### PR DESCRIPTION
- UI breaks on large decimal scale.
- incorrect nBTC balance.

## Summary by Sourcery

Fix incorrect NBTC decimal definition and add proper decimalScale handling in BuyNBTC input to resolve UI break and incorrect balances.

Bug Fixes:
- Correct NBTC decimals from 9 to 8 to ensure accurate nBTC balances.
- Add decimalScale prop to the SUI input to prevent UI break on large decimal values.