### PR TITLE
feat: refactor the buy nBTC fee calculation

### DIFF
--- a/app/components/BuyNBTC/BuyNBTC.tsx
+++ b/app/components/BuyNBTC/BuyNBTC.tsx
@@ -156,8 +156,9 @@ export function BuyNBTC() {
 	}, [isSuiWalletConnected, suiAmount, trigger]);
 
 	const totalBalance = BigInt(balance?.totalBalance || "0");
-	const maxSUIAmount = balance?.totalBalance && totalBalance > 0 ? formatSUI(totalBalance - gasFee) : "0";
-	const isValidMaxSUIAmount = (balance?.totalBalance && maxSUIAmount !== "0") || false;
+	const suiAmountAfterFee = totalBalance - gasFee
+	const maxSUIAmount = balance?.totalBalance && totalBalance > 0 ? formatSUI(suiAmountAfterFee) : "0";
+	const isValidMaxSUIAmount = suiAmountAfterFee >= 0;
 
 	const suiAmountInputRules = {
 		validate: {

--- a/app/components/BuyNBTC/BuyNBTC.tsx
+++ b/app/components/BuyNBTC/BuyNBTC.tsx
@@ -156,7 +156,7 @@ export function BuyNBTC() {
 	}, [isSuiWalletConnected, suiAmount, trigger]);
 
 	const totalBalance = BigInt(balance?.totalBalance || "0");
-	const suiAmountAfterFee = totalBalance - gasFee
+	const suiAmountAfterFee = totalBalance - gasFee;
 	const isValidMaxSUIAmount = suiAmountAfterFee > 0;
 	const maxSUIAmount = formatSUI(suiAmountAfterFee);
 

--- a/app/components/BuyNBTC/BuyNBTC.tsx
+++ b/app/components/BuyNBTC/BuyNBTC.tsx
@@ -157,8 +157,8 @@ export function BuyNBTC() {
 
 	const totalBalance = BigInt(balance?.totalBalance || "0");
 	const suiAmountAfterFee = totalBalance - gasFee
-	const maxSUIAmount = balance?.totalBalance && totalBalance > 0 ? formatSUI(suiAmountAfterFee) : "0";
-	const isValidMaxSUIAmount = suiAmountAfterFee >= 0;
+	const isValidMaxSUIAmount = suiAmountAfterFee > 0;
+	const maxSUIAmount = formatSUI(suiAmountAfterFee);
 
 	const suiAmountInputRules = {
 		validate: {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- markdownlint-disable MD013 -->
<!-- markdownlint-disable MD012 -->


## Description

Closes: #XXXX

---

### Author Checklist

All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.\_

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  - `fix`: A bug fix
  - `docs`: Documentation only changes
  - `style`: Changes that do not affect the meaning of the code (formatting, missing semi-colons, etc)
  - `refactor`: A code change that neither fixes a bug nor adds a feature
  - `perf`: A code change that improves performance
  - `test`: Adding missing tests or correcting existing tests
  - `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  - `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  - `chore`: Other changes that don't modify src or test files
  - `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Refactor the buy nBTC component to centralize fee subtraction and simplify max SUI amount validation.

Enhancements:
- Calculate `suiAmountAfterFee` by subtracting the gas fee from total balance and use it for `maxSUIAmount`.
- Simplify `isValidMaxSUIAmount` check to directly verify `suiAmountAfterFee` is non-negative.