### PR TITLE
ci: use node-22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,26 +15,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # no cache - no need to install node
-      - uses: pnpm/action-setup@v4
-        with:
-          # version: 10 # already set version in package.json -> packageManager
-          run_install: |
-            - recursive: true
-              args: [--frozen-lockfile, --strict-peer-dependencies]
+      ## no cache - no need to install node
+      # - uses: pnpm/action-setup@v4
+      #   with:
+      #     # version: 10 # already set version in package.json -> packageManager
+      #     run_install: |
+      #       - recursive: true
+      #         args: [--frozen-lockfile, --strict-peer-dependencies]
 
       ### version with cache
-      # - uses: pnpm/action-setup@v4
-      #   name: Install pnpm
-      #   with:
-      #     run_install: false
-      # - name: Install Node.js
-      #   uses: actions/setup-node@v4
-      #   with:
-      #     node-version: 20
-      #     cache: "pnpm"
-      # - name: Install dependencies
-      #   run: pnpm install
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install
       ###
 
       - name: eslint


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- markdownlint-disable MD013 -->
<!-- markdownlint-disable MD012 -->


## Description

CI started to report a build issue: https://github.com/gonative-cc/byield/actions/runs/15775021755/job/44468120774

## Summary by Sourcery

Update the CI build workflow to use Node.js 22 and leverage pnpm caching for faster, more reliable installs

Enhancements:
- Remove the legacy no-cache pnpm setup and consolidate dependency installation steps

CI:
- Upgrade GitHub Actions to install Node.js v22 instead of v20
- Enable pnpm dependency caching in the build workflow