### PR TITLE
feat: make nBTC input dynamic

### DIFF
--- a/app/components/BuyNBTC/BuyNBTC.tsx
+++ b/app/components/BuyNBTC/BuyNBTC.tsx
@@ -2,15 +2,12 @@ import { useContext } from "react";
 import { Card, CardContent } from "../ui/card";
 import { WalletContext } from "~/providers/ByieldWalletProvider";
 import { Wallets } from "~/components/Wallet";
-import { parseSUI } from "~/lib/denoms";
 import { useNBTCBalance } from "../Wallet/SuiWallet/useNBTCBalance";
 import { NBTCBalance } from "./NBTCBalance";
 import { Instructions } from "./Instructions";
 import { BuyNBTCTabContent } from "./BuyNBTCTabContent";
 import { SellNBTCTabContent } from "./SellNBTCTabContent";
 import { Tabs } from "../ui/tabs";
-
-const BUY_NBTC_GAS = parseSUI("0.01");
 
 export function BuyNBTC() {
 	const { connectedWallet } = useContext(WalletContext);

--- a/app/components/BuyNBTC/SellNBTCTabContent.tsx
+++ b/app/components/BuyNBTC/SellNBTCTabContent.tsx
@@ -5,62 +5,112 @@ import { SuiModal } from "../Wallet/SuiWallet/SuiModal";
 import { Modal } from "../ui/dialog";
 import { TransactionStatus } from "./TransactionStatus";
 import { NBTCIcon, SUIIcon } from "../icons";
-import { NumericInput } from "../ui/NumericInput";
 import { useNBTC } from "./useNBTC";
-import { formatNBTC } from "~/lib/denoms";
+import { formatNBTC, parseNBTC } from "~/lib/denoms";
 import { PRICE_PER_NBTC_IN_SUI } from "~/lib/nbtc";
+import { FormProvider, useForm } from "react-hook-form";
+import { FormNumericInput } from "../form/FormNumericInput";
 
-const NBTC_TO_SELL = 2000n;
-const SUI_AMOUNT_RECEIVED_ON_SELL = NBTC_TO_SELL * (PRICE_PER_NBTC_IN_SUI / 2n);
+interface SellNBTCForm {
+	nBTCAmount: string;
+}
 
 export function SellNBTCTabContent() {
-	const { handleTransaction, resetMutation, isPending, isSuccess, isError, data, isSuiWalletConnected } =
-		useNBTC({ variant: "SELL" });
+	const {
+		handleTransaction,
+		resetMutation,
+		isPending,
+		isSuccess,
+		isError,
+		nBTCBalance,
+		data,
+		isSuiWalletConnected,
+	} = useNBTC({ variant: "SELL" });
+
+	const sellNBTCForm = useForm<SellNBTCForm>({
+		mode: "all",
+		reValidateMode: "onChange",
+		disabled: isPending || isSuccess || isError,
+	});
+
+	const { watch, handleSubmit, reset } = sellNBTCForm;
+	const inputnBTCAmount = watch("nBTCAmount");
+	const nBTCAmount = parseNBTC(
+		inputnBTCAmount?.length > 0 && inputnBTCAmount !== "." ? inputnBTCAmount : "0",
+	);
+	const SUI_AMOUNT_RECEIVED_ON_SELL = nBTCAmount * (PRICE_PER_NBTC_IN_SUI / 2n);
 
 	const resetForm = useCallback(() => {
 		resetMutation();
-	}, [resetMutation]);
+		reset({
+			nBTCAmount: "",
+		});
+	}, [reset, resetMutation]);
+
+	const suiAmountInputRules = {
+		validate: {
+			isWalletConnected: () => isSuiWalletConnected || "Please connect SUI wallet",
+			enoughBalance: (value: string) => {
+				if (nBTCBalance?.totalBalance) {
+					if (parseNBTC(value) <= BigInt(nBTCBalance.totalBalance)) {
+						return true;
+					}
+					return `You don't have enough nBTC balance.`;
+				}
+			},
+		},
+	};
 
 	return (
-		<div className="flex flex-col w-full gap-2">
-			<NumericInput
-				className="h-16"
-				value={formatNBTC(NBTC_TO_SELL)}
-				readOnly
-				rightAdornments={<NBTCIcon className="mr-5" />}
-			/>
-			<span className="tracking-tighter text-gray-500 text-sm dark:text-gray-400">
-				This is a fixed price sell. The nBTC will be sold at price 12,500.
-			</span>
-			<ArrowDown className="text-primary justify-center w-full flex p-0 m-0" />
-			<NumericInput
-				value={formatNBTC(SUI_AMOUNT_RECEIVED_ON_SELL)}
-				readOnly
-				className="h-16"
-				rightAdornments={<SUIIcon className="mr-2" />}
-			/>
-			{isSuiWalletConnected ? (
-				<Button
-					type="button"
-					onClick={() => handleTransaction(0n)}
-					disabled={isPending}
-					isLoading={isPending}
-				>
-					Sell nBTC
-					<ChevronRight />
-				</Button>
-			) : (
-				<SuiModal />
-			)}
-			{(isSuccess || isError) && (
-				<Modal title={"Sell nBTC Transaction Status"} open handleClose={resetForm}>
-					<TransactionStatus
-						isSuccess={data?.effects?.status?.status === "success"}
-						handleRetry={resetForm}
-						txnId={data?.digest}
+		<FormProvider {...sellNBTCForm}>
+			<form
+				onSubmit={(e) =>
+					handleSubmit(() => {
+						handleTransaction(nBTCAmount);
+					})(e)
+				}
+				className="flex w-full flex-col gap-2"
+			>
+				<div className="flex flex-col w-full gap-2">
+					<FormNumericInput
+						required
+						name="nBTCAmount"
+						placeholder="Enter nBTC amount"
+						className="h-16"
+						rightAdornments={<NBTCIcon className="mr-5" />}
+						rules={suiAmountInputRules}
+						createEmptySpace
 					/>
-				</Modal>
-			)}
-		</div>
+					<span className="tracking-tighter text-gray-500 text-sm dark:text-gray-400">
+						This is a fixed price sell. The nBTC will be sold at price 12,500.
+					</span>
+					<ArrowDown className="text-primary justify-center w-full flex p-0 m-0" />
+					<FormNumericInput
+						name="SUIAmountReceived"
+						value={formatNBTC(SUI_AMOUNT_RECEIVED_ON_SELL)}
+						readOnly
+						className="h-16"
+						rightAdornments={<SUIIcon className="mr-2" />}
+					/>
+					{isSuiWalletConnected ? (
+						<Button type="submit" disabled={isPending} isLoading={isPending}>
+							Sell nBTC
+							<ChevronRight />
+						</Button>
+					) : (
+						<SuiModal />
+					)}
+					{(isSuccess || isError) && (
+						<Modal title={"Sell nBTC Transaction Status"} open handleClose={resetForm}>
+							<TransactionStatus
+								isSuccess={data?.effects?.status?.status === "success"}
+								handleRetry={resetForm}
+								txnId={data?.digest}
+							/>
+						</Modal>
+					)}
+				</div>
+			</form>
+		</FormProvider>
 	);
 }

--- a/app/components/BuyNBTC/SellNBTCTabContent.tsx
+++ b/app/components/BuyNBTC/SellNBTCTabContent.tsx
@@ -34,11 +34,11 @@ export function SellNBTCTabContent() {
 	});
 
 	const { watch, handleSubmit, reset } = sellNBTCForm;
-	const inputnBTCAmount = watch("nBTCAmount");
+	const inputNBTCAmount = watch("nBTCAmount");
 	const nBTCAmount = parseNBTC(
-		inputnBTCAmount?.length > 0 && inputnBTCAmount !== "." ? inputnBTCAmount : "0",
+		inputNBTCAmount?.length > 0 && inputNBTCAmount !== "." ? inputNBTCAmount : "0",
 	);
-	const SUI_AMOUNT_RECEIVED_ON_SELL = nBTCAmount * (PRICE_PER_NBTC_IN_SUI / 2n);
+	const SUIAmountReceived = nBTCAmount * (PRICE_PER_NBTC_IN_SUI / 2n);
 
 	const resetForm = useCallback(() => {
 		resetMutation();
@@ -47,7 +47,7 @@ export function SellNBTCTabContent() {
 		});
 	}, [reset, resetMutation]);
 
-	const suiAmountInputRules = {
+	const nBTCAmountInputRules = {
 		validate: {
 			isWalletConnected: () => isSuiWalletConnected || "Please connect SUI wallet",
 			enoughBalance: (value: string) => {
@@ -71,45 +71,43 @@ export function SellNBTCTabContent() {
 				}
 				className="flex w-full flex-col gap-2"
 			>
-				<div className="flex flex-col w-full gap-2">
-					<FormNumericInput
-						required
-						name="nBTCAmount"
-						placeholder="Enter nBTC amount"
-						className="h-16"
-						rightAdornments={<NBTCIcon className="mr-5" />}
-						rules={suiAmountInputRules}
-						createEmptySpace
-					/>
-					<span className="tracking-tighter text-gray-500 text-sm dark:text-gray-400">
-						This is a fixed price sell. The nBTC will be sold at price 12,500.
-					</span>
-					<ArrowDown className="text-primary justify-center w-full flex p-0 m-0" />
-					<FormNumericInput
-						name="SUIAmountReceived"
-						value={formatNBTC(SUI_AMOUNT_RECEIVED_ON_SELL)}
-						readOnly
-						className="h-16"
-						rightAdornments={<SUIIcon className="mr-2" />}
-					/>
-					{isSuiWalletConnected ? (
-						<Button type="submit" disabled={isPending} isLoading={isPending}>
-							Sell nBTC
-							<ChevronRight />
-						</Button>
-					) : (
-						<SuiModal />
-					)}
-					{(isSuccess || isError) && (
-						<Modal title={"Sell nBTC Transaction Status"} open handleClose={resetForm}>
-							<TransactionStatus
-								isSuccess={data?.effects?.status?.status === "success"}
-								handleRetry={resetForm}
-								txnId={data?.digest}
-							/>
-						</Modal>
-					)}
-				</div>
+				<FormNumericInput
+					required
+					name="nBTCAmount"
+					placeholder="Enter nBTC amount"
+					className="h-16"
+					rightAdornments={<NBTCIcon className="mr-5" />}
+					rules={nBTCAmountInputRules}
+					createEmptySpace
+				/>
+				<ArrowDown className="text-primary justify-center w-full flex p-0 m-0" />
+				<FormNumericInput
+					name="SUIAmountReceived"
+					value={formatNBTC(SUIAmountReceived)}
+					readOnly
+					className="h-16"
+					rightAdornments={<SUIIcon className="mr-2" />}
+				/>
+				<span className="tracking-tighter text-gray-500 text-sm dark:text-gray-400">
+					This is a fixed price sell. The nBTC will be sold at price 12,500.
+				</span>
+				{isSuiWalletConnected ? (
+					<Button type="submit" disabled={isPending} isLoading={isPending}>
+						Sell nBTC
+						<ChevronRight />
+					</Button>
+				) : (
+					<SuiModal />
+				)}
+				{(isSuccess || isError) && (
+					<Modal title={"Sell nBTC Transaction Status"} open handleClose={resetForm}>
+						<TransactionStatus
+							isSuccess={data?.effects?.status?.status === "success"}
+							handleRetry={resetForm}
+							txnId={data?.digest}
+						/>
+					</Modal>
+				)}
 			</form>
 		</FormProvider>
 	);

--- a/app/lib/nbtc.ts
+++ b/app/lib/nbtc.ts
@@ -4,7 +4,6 @@ import { fetchUTXOs, fetchValidateAddress } from "~/api/btcrpc";
 import type { UTXO, ValidateAddressI } from "~/api/btcrpc";
 import { ToastFunction } from "~/hooks/use-toast";
 
-export const NBTC_TO_SELL = 2000n;
 export const PRICE_PER_NBTC_IN_SUI = 25000n;
 export const nBTC_ADDR = "tb1qe60n447jylrxa96y6pfgy8pq6x9zafu09ky7cq";
 export const NBTC_COIN_TYPE =


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- markdownlint-disable MD013 -->
<!-- markdownlint-disable MD012 -->


## Description

Closes: #130 

---

### Author Checklist

All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.\_

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  - `fix`: A bug fix
  - `docs`: Documentation only changes
  - `style`: Changes that do not affect the meaning of the code (formatting, missing semi-colons, etc)
  - `refactor`: A code change that neither fixes a bug nor adds a feature
  - `perf`: A code change that improves performance
  - `test`: Adding missing tests or correcting existing tests
  - `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  - `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  - `chore`: Other changes that don't modify src or test files
  - `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Allow users to specify how much nBTC to sell by integrating a form input, validating balance and wallet connection, and updating transaction handlers to use the dynamic amount.

New Features:
- Enable dynamic input of nBTC amount when selling instead of using a fixed value

Enhancements:
- Replace fixed sell tab UI with a react-hook-form based form and client-side validation for wallet connection and balance checks
- Update transaction logic (useNBTC and createNBTCTxn) to propagate the user-entered amount throughout sell flows
- Remove the hardcoded NBTC_TO_SELL constant and calculate SUI output based on parsed input