### PR TITLE
feat: add max button in sell nBTC

### DIFF
--- a/app/components/BuyNBTC/SellNBTCTabContent.tsx
+++ b/app/components/BuyNBTC/SellNBTCTabContent.tsx
@@ -10,15 +10,16 @@ import { formatNBTC, NBTC, parseNBTC } from "~/lib/denoms";
 import { PRICE_PER_NBTC_IN_SUI } from "~/lib/nbtc";
 import { FormProvider, useForm } from "react-hook-form";
 import { FormNumericInput } from "../form/FormNumericInput";
+import { classNames } from "~/util/tailwind";
 
 interface NBTCRightAdornmentProps {
 	maxNBTCAmount: bigint;
 	onMaxClick: (val: string) => void;
+	isValidMaxNBTCAmount: boolean;
 }
 
-function NBTCRightAdornment({ maxNBTCAmount, onMaxClick }: NBTCRightAdornmentProps) {
+function NBTCRightAdornment({ maxNBTCAmount, isValidMaxNBTCAmount, onMaxClick }: NBTCRightAdornmentProps) {
 	const totalNBTCBalance = formatNBTC(maxNBTCAmount);
-	const isValidMaxNBTCAmount = maxNBTCAmount > 0;
 
 	return (
 		<div className="flex flex-col items-center gap-2 py-2">
@@ -94,6 +95,8 @@ export function SellNBTCTabContent() {
 		},
 	};
 
+	const isValidMaxNBTCAmount = nBTCBalance?.totalBalance ? BigInt(nBTCBalance.totalBalance) > 0 : false;
+
 	return (
 		<FormProvider {...sellNBTCForm}>
 			<form
@@ -108,11 +111,15 @@ export function SellNBTCTabContent() {
 					required
 					name="nBTCAmount"
 					placeholder="Enter nBTC amount"
-					className="h-16"
+					className={classNames({
+						"h-16": true,
+						"pt-8": isValidMaxNBTCAmount,
+					})}
 					rightAdornments={
 						<NBTCRightAdornment
 							onMaxClick={(val: string) => setValue("nBTCAmount", val)}
 							maxNBTCAmount={BigInt(nBTCBalance?.totalBalance || "0")}
+							isValidMaxNBTCAmount={isValidMaxNBTCAmount}
 						/>
 					}
 					rules={nBTCAmountInputRules}

--- a/app/components/BuyNBTC/SellNBTCTabContent.tsx
+++ b/app/components/BuyNBTC/SellNBTCTabContent.tsx
@@ -11,6 +11,39 @@ import { PRICE_PER_NBTC_IN_SUI } from "~/lib/nbtc";
 import { FormProvider, useForm } from "react-hook-form";
 import { FormNumericInput } from "../form/FormNumericInput";
 
+interface NBTCRightAdornmentProps {
+	maxNBTCAmount: bigint;
+	onMaxClick: (val: string) => void;
+}
+
+function NBTCRightAdornment({ maxNBTCAmount, onMaxClick }: NBTCRightAdornmentProps) {
+	const totalNBTCBalance = formatNBTC(maxNBTCAmount);
+	const isValidMaxNBTCAmount = maxNBTCAmount > 0;
+
+	return (
+		<div className="flex flex-col items-center gap-2 py-2">
+			{isValidMaxNBTCAmount && (
+				<div className="flex items-center gap-2">
+					<p className="text-xs whitespace-nowrap">Balance: {totalNBTCBalance} nBTC</p>
+					<Button
+						variant="link"
+						type="button"
+						onClick={() => onMaxClick(totalNBTCBalance)}
+						className="text-xs w-fit p-0 pr-2 h-fit"
+					>
+						Max
+					</Button>
+				</div>
+			)}
+			<NBTCIcon
+				prefix={"nBTC"}
+				className="flex justify-end mr-1"
+				containerClassName="w-full justify-end"
+			/>
+		</div>
+	);
+}
+
 interface SellNBTCForm {
 	nBTCAmount: string;
 }
@@ -33,7 +66,7 @@ export function SellNBTCTabContent() {
 		disabled: isPending || isSuccess || isError,
 	});
 
-	const { watch, handleSubmit, reset } = sellNBTCForm;
+	const { watch, handleSubmit, reset, setValue } = sellNBTCForm;
 	const inputNBTCAmount = watch("nBTCAmount");
 	const nBTCAmount = parseNBTC(
 		inputNBTCAmount?.length > 0 && inputNBTCAmount !== "." ? inputNBTCAmount : "0",
@@ -76,7 +109,12 @@ export function SellNBTCTabContent() {
 					name="nBTCAmount"
 					placeholder="Enter nBTC amount"
 					className="h-16"
-					rightAdornments={<NBTCIcon className="mr-5" />}
+					rightAdornments={
+						<NBTCRightAdornment
+							onMaxClick={(val: string) => setValue("nBTCAmount", val)}
+							maxNBTCAmount={BigInt(nBTCBalance?.totalBalance || "0")}
+						/>
+					}
 					rules={nBTCAmountInputRules}
 					createEmptySpace
 					decimalScale={NBTC}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- markdownlint-disable MD013 -->
<!-- markdownlint-disable MD012 -->


## Description

Closes: #142 

---

### Author Checklist

All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.\_

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  - `fix`: A bug fix
  - `docs`: Documentation only changes
  - `style`: Changes that do not affect the meaning of the code (formatting, missing semi-colons, etc)
  - `refactor`: A code change that neither fixes a bug nor adds a feature
  - `perf`: A code change that improves performance
  - `test`: Adding missing tests or correcting existing tests
  - `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  - `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  - `chore`: Other changes that don't modify src or test files
  - `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Add a Max button to the Sell nBTC form input that fills the user's entire nBTC balance, extract the input adornment into its own component, and clean up className formatting in the Sidebar.

New Features:
- Add a clickable Max button to the Sell nBTC input field to auto-fill the user's total nBTC balance.

Enhancements:
- Extract the balance display and Max button into a new NBTCRightAdornment component for reuse.

Chores:
- Reformat className strings in the Sidebar component for consistent styling.