### PR TITLE
feat: add swap nBTC to SUI warning

### DIFF
--- a/app/pages/BuyNBTC/SellNBTCTabContent.tsx
+++ b/app/pages/BuyNBTC/SellNBTCTabContent.tsx
@@ -135,9 +135,15 @@ export function SellNBTCTabContent() {
 					className="h-16"
 					rightAdornments={<SUIIcon className="mr-2" />}
 				/>
-				<span className="tracking-tighter text-gray-500 text-sm dark:text-gray-400">
-					This is a fixed price sell. The nBTC will be sold at price 12,500.
-				</span>
+				<div className="flex flex-col gap-2">
+					<span className="tracking-tighter text-gray-500 text-sm dark:text-gray-400">
+						This is a fixed price sell. The nBTC will be sold at price 12,500.
+					</span>
+					<span className="tracking-tighter text-gray-500 text-sm dark:text-gray-400">
+						<span className="font-bold">Testnet measure:</span>To reduce testnet bot spam, nBTC to
+						SUI swaps have a 50% reduction.
+					</span>
+				</div>
 				{isSuiWalletConnected ? (
 					<Button type="submit" disabled={isPending} isLoading={isPending}>
 						Sell nBTC


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- markdownlint-disable MD013 -->
<!-- markdownlint-disable MD012 -->


## Description

Closes: #153 

---

### Author Checklist

All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.\_

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  - `fix`: A bug fix
  - `docs`: Documentation only changes
  - `style`: Changes that do not affect the meaning of the code (formatting, missing semi-colons, etc)
  - `refactor`: A code change that neither fixes a bug nor adds a feature
  - `perf`: A code change that improves performance
  - `test`: Adding missing tests or correcting existing tests
  - `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  - `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  - `chore`: Other changes that don't modify src or test files
  - `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Add a testnet measure warning under the fixed price sell section to inform users about the 50% reduction on nBTC to SUI swaps and adjust the layout to accommodate the new message

New Features:
- Show a testnet-specific warning for nBTC to SUI swaps indicating a 50% reduction to mitigate bot spam

Enhancements:
- Wrap existing sell price message and the new testnet warning in a flex container for proper layout spacing