### PR TITLE
style: remove ActionType

### DIFF
--- a/app/hooks/use-toast.ts
+++ b/app/hooks/use-toast.ts
@@ -13,13 +13,6 @@ type ToasterToast = ToastProps & {
 	action?: ToastActionElement;
 };
 
-const actionTypes = {
-	ADD_TOAST: "ADD_TOAST",
-	UPDATE_TOAST: "UPDATE_TOAST",
-	DISMISS_TOAST: "DISMISS_TOAST",
-	REMOVE_TOAST: "REMOVE_TOAST",
-} as const;
-
 let count = 0;
 
 function genId() {
@@ -27,23 +20,21 @@ function genId() {
 	return count.toString();
 }
 
-type ActionType = typeof actionTypes;
-
 type Action =
 	| {
-			type: ActionType["ADD_TOAST"];
+			type: "ADD_TOAST";
 			toast: ToasterToast;
 	  }
 	| {
-			type: ActionType["UPDATE_TOAST"];
+			type: "UPDATE_TOAST";
 			toast: Partial<ToasterToast>;
 	  }
 	| {
-			type: ActionType["DISMISS_TOAST"];
+			type: "DISMISS_TOAST";
 			toastId?: ToasterToast["id"];
 	  }
 	| {
-			type: ActionType["REMOVE_TOAST"];
+			type: "REMOVE_TOAST";
 			toastId?: ToasterToast["id"];
 	  };
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- markdownlint-disable MD013 -->
<!-- markdownlint-disable MD012 -->


## Description

We already have fixed `type Action` type definition. No need to make an obscure `actionTypes`.

## Summary by Sourcery

Simplify toast action typing by removing the actionTypes mapping and ActionType alias and using direct string literals in the Action union

Enhancements:
- Remove the redundant actionTypes constant
- Eliminate the ActionType alias and inline string literals in the Action union