### PR TITLE
feat: bid more

### DIFF
--- a/app/config/sui/contracts-testnet.json
+++ b/app/config/sui/contracts-testnet.json
@@ -7,9 +7,9 @@
 		"sellNBTCFunction": "sell_nbtc"
 	},
 	"auctionBidApi": {
-		"packageId": "0xb7e30b29c622f9d595b5d8e262d6bbab9fe8ad10de220062df2246842cf5ad4d",
+		"packageId": "0xd5b24b83b168f8656aa7c05af1256e6115de1b80d97be0cddf19297a15535149",
 		"module": "auction",
 		"bidEndpoint": "bid",
-		"auctionId": "0x43c64bbd8cb484aabd389549f05c2b22d0d1695fff649c40ffccb1ed72859dfa"
+		"auctionId": "0xc9d2f1b373e770b77668e5556bd4466c37963f01159c10a71a0bf2d4000877c0"
 	}
 }

--- a/app/pages/BeelieversAuction/BeelieversBid.tsx
+++ b/app/pages/BeelieversAuction/BeelieversBid.tsx
@@ -51,7 +51,7 @@ function MyPosition({ userBid, hasUserBidBefore }: MyPositionProps) {
 
 function validateBidAmount(val: string, hasUserBidBefore: boolean) {
 	const bidAmount = Number(val);
-	if (!hasUserBidBefore && bidAmount < 1) {
+	if (!hasUserBidBefore && bidAmount < 0.1) {
 		return "First-time bidders must bid at least 1 SUI";
 	}
 	if (bidAmount <= 0) {

--- a/app/server/BeelieversAuction/defaults.ts
+++ b/app/server/BeelieversAuction/defaults.ts
@@ -26,7 +26,7 @@ function testAuctionDetails(): AuctionDetails {
 		highestBidMist: 30e9,
 		entryBidMist: 2e9,
 		startsAt,
-		endsAt: startsAt + 24 * 3600_000,
+		endsAt: startsAt + 199 * 3600_000,
 	};
 }
 


### PR DESCRIPTION
## Description

Closes: #XXXX

---

### Author Checklist

All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.\_

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  - `fix`: A bug fix
  - `docs`: Documentation only changes
  - `style`: Changes that do not affect the meaning of the code (formatting, missing semi-colons, etc)
  - `refactor`: A code change that neither fixes a bug nor adds a feature
  - `perf`: A code change that improves performance
  - `test`: Adding missing tests or correcting existing tests
  - `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  - `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  - `chore`: Other changes that don't modify src or test files
  - `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Implement incremental bidding by querying and decoding the current user bid, enforcing that new bids exceed the existing total, and automatically subtracting the prior bid from the entered amount. Lower the first-time minimum bid to 0.1 SUI and extend the default test auction duration to 199 hours.

New Features:
- Introduce getCurrentBidAmount to fetch and decode user’s current total bid via devInspectTransactionBlock
- Integrate incremental bidding by subtracting existing bid from the entered amount before placing a new bid

Enhancements:
- Lower the first-time bid minimum requirement from 1 SUI to 0.1 SUI
- Extend the default test auction duration from 24 to 199 hours