### PR TITLE
feat: map badge name in backend

### DIFF
--- a/app/lib/badgeSystem.ts
+++ b/app/lib/badgeSystem.ts
@@ -1,40 +1,42 @@
+import { Badge } from "~/server/BeelieversAuction/types";
+
 export interface BadgeRecord {
-	name: string;
+	name: Badge;
 	filename: string;
 	src: string;
 }
 
 // Badge name to filename mapping for backend integration
-export const BADGE_NAME_TO_FILENAME: Record<string, string> = {
-	first_place: "Sui_Logo_1stspot.svg",
-	top_3: "Crown_top_3.svg",
-	top_10: "Native_top10.svg",
-	top_21: "Bitcoin_top21.svg",
-	top_100: "Whale_for_top_100.svg",
-	top_5810: "Everyone_in_top_5810_positions.svg",
-	highest_bid: "highest_single_bid.svg",
-	bid_over_10: "Single_bid_over_10_Sui.svg",
-	bid_over_5: "Single_bid_over_5_Sui.svg",
-	bid_over_3: "Single_bid_over_3_Sui.svg",
-	bids_over_10: "10_or_more_bids.svg",
-	bids_over_20: "20_or_more_bids.svg",
-	bids_over_5: "made_5_or_more_bids.svg",
-	partner_wl: "Partner_WL_addresses_badge.svg",
-	first_500: "first_500_bids.svg",
-	first_1000: "first_1000_bids.svg",
-	climb_up_210_position: "anyone_climbs_more_than_210_positions_up.svg",
-	climb_10_spots: "if_anyone_climbs_10_spots_in_a_single_bid.svg",
-	comeback_top_10: "If_some_one_comesback_to_top_10_after_falling_off_10.svg",
-	last_bid: "Last_bid_in_Leaderboard.svg",
-	every_10th_position: "Logo_Ika_red_every_10th_position.svg",
-	made_2nd_position: "Made_2nd_bid.svg",
-	made_3rd_bid: "made_3rd_bid.svg",
-	made_4th_bid: "Made_4th_bid.svg",
-	nbtc_every_21st_bidder: "nbtc_every_21st_bidder.svg",
-	dethrone: "Who_dethrones_someone_and_gets_number_1_spot.svg",
+export const BADGE_NAME_TO_FILENAME: Record<Badge, string> = {
+	[Badge.first_place]: "Sui_Logo_1stspot.svg",
+	[Badge.top_3]: "Crown_top_3.svg",
+	[Badge.top_10]: "Native_top10.svg",
+	[Badge.top_21]: "Bitcoin_top21.svg",
+	[Badge.top_100]: "Whale_for_top_100.svg",
+	[Badge.top_5810]: "Everyone_in_top_5810_positions.svg",
+	[Badge.highest_bid]: "highest_single_bid.svg",
+	[Badge.bid_over_10]: "Single_bid_over_10_Sui.svg",
+	[Badge.bid_over_5]: "Single_bid_over_5_Sui.svg",
+	[Badge.bid_over_3]: "Single_bid_over_3_Sui.svg",
+	[Badge.bids_over_10]: "10_or_more_bids.svg",
+	[Badge.bids_over_20]: "20_or_more_bids.svg",
+	[Badge.bids_over_5]: "made_5_or_more_bids.svg",
+	[Badge.partner_wl]: "Partner_WL_addresses_badge.svg",
+	[Badge.first_500]: "first_500_bids.svg",
+	[Badge.first_1000]: "first_1000_bids.svg",
+	[Badge.climb_up_210_position]: "anyone_climbs_more_than_210_positions_up.svg",
+	[Badge.climb_10_spots]: "if_anyone_climbs_10_spots_in_a_single_bid.svg",
+	[Badge.comeback_top_10]: "If_some_one_comesback_to_top_10_after_falling_off_10.svg",
+	[Badge.last_bid]: "Last_bid_in_Leaderboard.svg",
+	[Badge.every_10th_position]: "Logo_Ika_red_every_10th_position.svg",
+	[Badge.made_2nd_position]: "Made_2nd_bid.svg",
+	[Badge.made_3rd_bid]: "made_3rd_bid.svg",
+	[Badge.made_4th_bid]: "Made_4th_bid.svg",
+	[Badge.nbtc_every_21st_bidder]: "nbtc_every_21st_bidder.svg",
+	[Badge.dethrone]: "Who_dethrones_someone_and_gets_number_1_spot.svg",
 };
 
-export function toBadgeRecord(badgeName: string): BadgeRecord | null {
+export function toBadgeRecord(badgeName: Badge): BadgeRecord | null {
 	const filename = BADGE_NAME_TO_FILENAME[badgeName];
 	if (!filename) return null;
 

--- a/app/pages/BeelieversAuction/AuctionTable.tsx
+++ b/app/pages/BeelieversAuction/AuctionTable.tsx
@@ -77,7 +77,7 @@ const createColumns = (): Column<Bidder>[] => [
 							<img
 								key={index}
 								src={badge.src}
-								alt={badge!.name}
+								alt={String(badge!.name)}
 								className={`bg-gray-400 w-8 h-8 hover:scale-110 transition-transform cursor-help`}
 							/>
 						))

--- a/app/server/BeelieversAuction/defaults.ts
+++ b/app/server/BeelieversAuction/defaults.ts
@@ -1,4 +1,4 @@
-import { AuctionAccountType, type AuctionDetails, type User } from "./types";
+import { AuctionAccountType, Badge, type AuctionDetails, type User } from "./types";
 
 import { isProductionMode } from "~/lib/appenv";
 
@@ -47,7 +47,13 @@ function defaultTestUser(): User {
 	return {
 		rank: 9, // rank starts from 1
 		amount: 5_1 * 1e8, // 5.1 SUI
-		badges: ["top_10", "top_21", "top_100", "bid_over_5", "every_21st"],
+		badges: [
+			Badge.top_10,
+			Badge.top_21,
+			Badge.top_100,
+			Badge.bid_over_5,
+			Badge.nbtc_every_21st_bidder,
+		],
 		note: "I'm Beellish!",
 		wlStatus: AuctionAccountType.PARTNER_WHITELIST,
 	};

--- a/app/server/BeelieversAuction/leaderboard.server.ts
+++ b/app/server/BeelieversAuction/leaderboard.server.ts
@@ -1,4 +1,4 @@
-import type { Bidder } from "./types";
+import { Badge, type Bidder } from "./types";
 
 // TODO: leader board API integration
 const MOCK_LEADER_BOARD_DATA: Bidder[] = [
@@ -6,7 +6,7 @@ const MOCK_LEADER_BOARD_DATA: Bidder[] = [
 		rank: 1,
 		bidder: "0xe670405731f97182a4e5056b63385ddd6f7929dfa1a64f82c5f0bdd780dc79f4",
 		amount: 100, // Highest bid - will get "highest single bid" badge
-		badges: ["first_place", "highest_bid"],
+		badges: [Badge.first_place, Badge.highest_bid],
 		note: "",
 	},
 	{

--- a/app/server/BeelieversAuction/types.ts
+++ b/app/server/BeelieversAuction/types.ts
@@ -23,7 +23,7 @@ interface User_ {
 	rank: number | null; // null => outside of the winning list
 	// amount bid in MIST. 0 => no bid placed
 	amount: number;
-	badges: string[];
+	badges: Badge[];
 	note: string;
 }
 
@@ -44,4 +44,33 @@ export interface LoaderData {
 // TODO move to controller
 export interface LoaderDataResp extends LoaderData {
 	error?: Error;
+}
+
+export enum Badge {
+	first_place = 1,
+	top_3 = 2,
+	top_10 = 3,
+	top_21 = 4,
+	top_100 = 5,
+	top_5810 = 6,
+	highest_bid = 7,
+	bid_over_10 = 8,
+	bid_over_5 = 9,
+	bid_over_3 = 10,
+	bids_over_10 = 11,
+	bids_over_20 = 12,
+	bids_over_5 = 13,
+	partner_wl = 14,
+	first_500 = 15,
+	first_1000 = 16,
+	climb_up_210_position = 17,
+	climb_10_spots = 18,
+	comeback_top_10 = 19,
+	last_bid = 20,
+	every_10th_position = 21,
+	made_2nd_position = 22,
+	made_3rd_bid = 23,
+	made_4th_bid = 24,
+	nbtc_every_21st_bidder = 25,
+	dethrone = 26,
 }


### PR DESCRIPTION
## Description

Closes: #XXXX

---

### Author Checklist

All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.\_

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  - `fix`: A bug fix
  - `docs`: Documentation only changes
  - `style`: Changes that do not affect the meaning of the code (formatting, missing semi-colons, etc)
  - `refactor`: A code change that neither fixes a bug nor adds a feature
  - `perf`: A code change that improves performance
  - `test`: Adding missing tests or correcting existing tests
  - `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  - `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  - `chore`: Other changes that don't modify src or test files
  - `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Introduce a Badge enum and replace string-based badge identifiers with enum values across backend and frontend badge mapping and types

Enhancements:
- Define a new Badge enum listing all auction badge identifiers
- Update badgeSystem mapping and toBadgeRecord to use Badge enum keys instead of strings
- Refactor user and bidder types to use Badge[] instead of string[] for badges
- Adjust default and mock data to use enum values for badges
- Update AuctionTable component to render enum-based badge names in alt attributes