### PR TITLE
feat: show user rank always at the top with his bid status

### DIFF
--- a/app/pages/BeelieversAuction/AuctionTable.tsx
+++ b/app/pages/BeelieversAuction/AuctionTable.tsx
@@ -91,16 +91,17 @@ const createColumns = (): Column<Bidder>[] => [
 ];
 
 export function AuctionTable({ data, user, suiAddr }: AuctionTableProps) {
-	const userPosition = user?.rank;
-
 	const getDisplayData = (): Bidder[] => {
-		const top21 = data.slice(0, MAX_LEADERBOARD_ROWS);
-
-		if (userPosition && userPosition > MAX_LEADERBOARD_ROWS && user && suiAddr) {
+		const top21: Bidder[] = data.slice(0, MAX_LEADERBOARD_ROWS);
+		if (user && suiAddr) {
+			const top20: Bidder[] = data
+				.slice(0, MAX_LEADERBOARD_ROWS)
+				.filter(({ bidder }) => bidder !== suiAddr);
 			const currentBidder: Bidder = { ...user, bidder: suiAddr };
-			return [...top21, currentBidder];
+			// always show user position at the top of the table
+			// total user: 1 + 20
+			return [currentBidder, ...top20];
 		}
-
 		return top21;
 	};
 

--- a/app/pages/BeelieversAuction/BeelieversAuction.tsx
+++ b/app/pages/BeelieversAuction/BeelieversAuction.tsx
@@ -9,6 +9,7 @@ import { makeReq } from "~/server/BeelieversAuction/jsonrpc";
 import { useFetcher } from "react-router";
 import { useContext, useEffect, useRef } from "react";
 import { WalletContext } from "~/providers/ByieldWalletProvider";
+import { MyPosition } from "./MyPosition";
 
 function getAuctionState(startMs: number, endMs: number): AuctionState {
 	const nowMs = new Date().getTime();
@@ -78,6 +79,12 @@ export function BeelieversAuction({
 			{auctionState == AuctionState.STARTED && (
 				<div className="animate-in slide-in-from-right-4 duration-1000 delay-500 w-full flex justify-center">
 					<BeelieversBid user={user} entryBidMist={entryBidMist} />
+				</div>
+			)}
+
+			{user && (
+				<div className="animate-in slide-in-from-right-4 duration-1000 delay-500 w-full flex justify-center">
+					<MyPosition user={user} />
 				</div>
 			)}
 

--- a/app/pages/BeelieversAuction/BeelieversBid.tsx
+++ b/app/pages/BeelieversAuction/BeelieversBid.tsx
@@ -16,11 +16,6 @@ import { useCurrentAccount, useSignAndExecuteTransaction } from "@mysten/dapp-ki
 import { LoaderCircle } from "lucide-react";
 import { SUIIcon } from "~/components/icons";
 
-interface MyPositionProps {
-	user: User;
-	hasUserBidBefore: boolean;
-}
-
 interface NewTotalBidAmountProps {
 	currentBidInMist: number;
 	entryBidMist: number;
@@ -57,36 +52,6 @@ function NewTotalBidAmount({ currentBidInMist, additionalBidInSUI, entryBidMist 
 				</div>
 			)}
 		</div>
-	);
-}
-
-function MyPosition({ user, hasUserBidBefore }: MyPositionProps) {
-	return (
-		<Card className="border-primary/30 bg-gradient-to-r from-primary/10 to-primary/5 animate-in slide-in-from-top-2 duration-500">
-			<CardContent className="p-4 lg:p-6">
-				<div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-					<div className="flex items-center gap-3">
-						<div className="w-10 h-10 rounded-full bg-primary flex items-center justify-center">
-							<span className="text-xl">🎯</span>
-						</div>
-						<div>
-							<h3 className="font-semibold text-primary">Your Current Bid</h3>
-							<p className="text-sm text-muted-foreground">
-								{hasUserBidBefore ? `Rank #${user.rank}` : "No bid placed"}
-							</p>
-						</div>
-					</div>
-					{hasUserBidBefore && (
-						<div className="text-right">
-							<p className="text-2xl font-bold text-primary">
-								{formatSUI(String(user.amount))} SUI
-							</p>
-							{user?.note && <p className="text-sm text-muted-foreground">{user.note}</p>}
-						</div>
-					)}
-				</div>
-			</CardContent>
-		</Card>
 	);
 }
 
@@ -171,9 +136,6 @@ export function BeelieversBid({ user, entryBidMist }: BeelieversBidProps) {
 		<FormProvider {...bidForm}>
 			<form onSubmit={onSubmit} className="flex justify-center w-full">
 				<div className="w-full lg:w-2/3 xl:w-1/2 space-y-6">
-					{/* Current Bid Status */}
-					{user && <MyPosition user={user} hasUserBidBefore={hasUserBidBefore} />}
-
 					<Card className="shadow-2xl border-primary/20 hover:border-primary/40 transition-all duration-300 animate-in slide-in-from-bottom-2 duration-700">
 						<CardContent className="p-6 lg:p-8 rounded-lg text-white flex flex-col w-full gap-6 bg-gradient-to-br from-azure-10 via-azure-15 to-azure-20">
 							<div className="flex items-center justify-between">

--- a/app/pages/BeelieversAuction/MyPosition.tsx
+++ b/app/pages/BeelieversAuction/MyPosition.tsx
@@ -1,0 +1,72 @@
+import { Card, CardContent } from "~/components/ui/card";
+import { formatSUI } from "~/lib/denoms";
+import type { User } from "~/server/BeelieversAuction/types";
+import { toBadgeRecord } from "~/lib/badgeSystem";
+
+interface MyPositionProps {
+	user: User;
+}
+
+export function MyPosition({ user }: MyPositionProps) {
+	const userBadges = user.badges?.map(toBadgeRecord).filter(Boolean) || [];
+	const hasUserBidBefore = (user && user.amount !== 0) || false;
+
+	return (
+		<div className="flex justify-center w-full">
+			<div className="w-full lg:w-2/3 xl:w-1/2">
+				<Card className="border-primary/30 bg-gradient-to-r from-primary/10 to-primary/5 animate-in slide-in-from-top-2 duration-500">
+					<CardContent className="p-4 lg:p-6">
+						<div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+							<div className="flex items-center gap-3">
+								<div className="w-10 h-10 rounded-full bg-primary flex items-center justify-center">
+									<span className="text-xl">🎯</span>
+								</div>
+								<div>
+									<h3 className="font-semibold text-primary">Your Current Bid</h3>
+									<p className="text-sm text-muted-foreground">
+										{hasUserBidBefore ? `Rank #${user.rank}` : "No bid placed"}
+									</p>
+								</div>
+							</div>
+							{hasUserBidBefore && (
+								<div className="text-right">
+									<p className="text-2xl font-bold text-primary">
+										{formatSUI(String(user.amount))} SUI
+									</p>
+									{user?.note && (
+										<p className="text-sm text-muted-foreground">{user.note}</p>
+									)}
+								</div>
+							)}
+						</div>
+						{userBadges.length > 0 && (
+							<div className="mt-4 pt-4 border-t border-primary/20">
+								<div className="flex items-center gap-2 mb-2">
+									<span className=" text-xl font-semibold text-primary">
+										🏆 Your Badges
+									</span>
+								</div>
+								<div className="flex flex-wrap gap-2">
+									{userBadges.length > 0 ? (
+										userBadges?.map((badge, index) => (
+											<img
+												key={index}
+												src={badge!.src}
+												alt={String(badge!.name)}
+												className={`bg-gray-400 w-8 h-8 hover:scale-110 transition-transform cursor-help`}
+											/>
+										))
+									) : (
+										<span className="text-muted-foreground text-sm">
+											Bid to see the badges
+										</span>
+									)}
+								</div>
+							</div>
+						)}
+					</CardContent>
+				</Card>
+			</div>
+		</div>
+	);
+}

--- a/app/pages/BeelieversAuction/MyPosition.tsx
+++ b/app/pages/BeelieversAuction/MyPosition.tsx
@@ -58,7 +58,7 @@ export function MyPosition({ user }: MyPositionProps) {
 										))
 									) : (
 										<span className="text-muted-foreground text-sm">
-											Bid to see the badges
+											You have no badges
 										</span>
 									)}
 								</div>


### PR DESCRIPTION
## Description

Closes: #XXXX

---

### Author Checklist

All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.\_

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  - `fix`: A bug fix
  - `docs`: Documentation only changes
  - `style`: Changes that do not affect the meaning of the code (formatting, missing semi-colons, etc)
  - `refactor`: A code change that neither fixes a bug nor adds a feature
  - `perf`: A code change that improves performance
  - `test`: Adding missing tests or correcting existing tests
  - `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  - `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  - `chore`: Other changes that don't modify src or test files
  - `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Extract the user position card into a reusable component with badge display and update the leaderboard logic to always show the current user first

New Features:
- Extract MyPosition into its own component to display the user’s current bid status and badges
- Add a badges section in MyPosition to surface user achievements

Enhancements:
- Always include the current user at the top of the auction leaderboard and filter them out of the main list to avoid duplication
- Embed MyPosition in the main auction page header and remove its inline use in the bid form