### PR TITLE
fix: fetcher response types.

### DIFF
--- a/app/pages/BeelieversAuction/AuctionTable.tsx
+++ b/app/pages/BeelieversAuction/AuctionTable.tsx
@@ -12,7 +12,7 @@ const MAX_LEADERBOARD_ROWS = 21;
 interface AuctionTableProps {
 	data: Bidder[];
 	suiAddr: string | null;
-	user?: User;
+	user: User | null;
 }
 
 const createColumns = (): Column<Bidder>[] => [

--- a/app/pages/BeelieversAuction/BeelieversAuction.tsx
+++ b/app/pages/BeelieversAuction/BeelieversAuction.tsx
@@ -3,8 +3,8 @@ import { useContext, useEffect, useRef, type ReactNode } from "react";
 import { AuctionTable } from "./AuctionTable";
 import { AuctionTotals } from "./AuctionTotals";
 import { AuctionState } from "./types";
-import type { AuctionInfo, Bidder, User } from "~/server/BeelieversAuction/types";
-import { makeReq, type RaffleResp, type UserResp } from "~/server/BeelieversAuction/jsonrpc";
+import type { AuctionInfo, Bidder } from "~/server/BeelieversAuction/types";
+import { makeReq, type QueryRaffleResp, type QueryUserResp } from "~/server/BeelieversAuction/jsonrpc";
 import { WalletContext } from "~/providers/ByieldWalletProvider";
 import { removeDuplicates, sortAndCheckDuplicate } from "~/lib/batteries";
 import { RaffleTable } from "./RaffleTable";
@@ -29,10 +29,10 @@ interface BeelieversAuctionProps {
 export function BeelieversAuction({ info, leaderboard }: BeelieversAuctionProps) {
 	const { suiAddr } = useContext(WalletContext);
 	const lastCheckedAddress = useRef<string | null>(null);
-	const userFetcher = useFetcher<UserResp>();
-	const raffleFetcher = useFetcher<RaffleResp>();
-	const user: UserResp = userFetcher.data ?? null;
-	const raffle: RaffleResp = raffleFetcher.data ?? null;
+	const userFetcher = useFetcher<QueryUserResp>();
+	const raffleFetcher = useFetcher<QueryRaffleResp>();
+	const user: QueryUserResp = userFetcher.data ?? null;
+	const raffle: QueryRaffleResp = raffleFetcher.data ?? null;
 	const auctionState = getAuctionState(info.startsAt, info.endsAt, info.clearingPrice);
 
 	console.log(">>>> raffle", raffle);
@@ -50,7 +50,7 @@ export function BeelieversAuction({ info, leaderboard }: BeelieversAuctionProps)
 		if (suiAddr && suiAddr !== lastCheckedAddress.current && userFetcher.state === "idle") {
 			// Wallet connected or address changed - check eligibility
 			lastCheckedAddress.current = suiAddr;
-			makeReq<UserResp>(userFetcher, { method: "queryUser", params: [suiAddr] });
+			makeReq<QueryUserResp>(userFetcher, { method: "queryUser", params: [suiAddr] });
 		} else if (!suiAddr && lastCheckedAddress.current) {
 			// Wallet disconnected - reset state
 			lastCheckedAddress.current = null;
@@ -60,7 +60,7 @@ export function BeelieversAuction({ info, leaderboard }: BeelieversAuctionProps)
 	useEffect(() => {
 		// query the raffle
 		if (raffleFetcher.state === "idle" && !raffle && auctionState === AuctionState.RECONCILLED) {
-			makeReq<RaffleResp>(raffleFetcher, { method: "queryRaffle", params: [] });
+			makeReq<QueryRaffleResp>(raffleFetcher, { method: "queryRaffle", params: [] });
 		}
 	}, [raffleFetcher, raffle, auctionState]);
 

--- a/app/pages/BeelieversAuction/BeelieversAuction.tsx
+++ b/app/pages/BeelieversAuction/BeelieversAuction.tsx
@@ -33,6 +33,7 @@ export function BeelieversAuction({ info, leaderboard }: BeelieversAuctionProps)
 	const raffleFetcher = useFetcher<RaffleResp>();
 	const user: User | undefined = userFetcher?.data;
 	const raffle: RaffleResp | undefined = raffleFetcher?.data;
+	const auctionState = getAuctionState(info.startsAt, info.endsAt, info.clearingPrice);
 
 	console.log(">>>> raffle", raffle);
 
@@ -58,12 +59,11 @@ export function BeelieversAuction({ info, leaderboard }: BeelieversAuctionProps)
 
 	useEffect(() => {
 		// query the raffle
-		if (raffleFetcher.state === "idle" && !raffle) {
+		if (raffleFetcher.state === "idle" && !raffle && auctionState === AuctionState.RECONCILLED) {
 			makeReq<RaffleResp | null>(raffleFetcher, { method: "queryRaffle", params: [] });
 		}
-	}, [raffleFetcher, raffle]);
+	}, [raffleFetcher, raffle, auctionState]);
 
-	const auctionState = getAuctionState(info.startsAt, info.endsAt, info.clearingPrice);
 	// TODO: get mint info
 	const showMintInfo = true;
 

--- a/app/pages/BeelieversAuction/MintInfo.tsx
+++ b/app/pages/BeelieversAuction/MintInfo.tsx
@@ -94,7 +94,7 @@ function MintAction({ refund }: MintActionProps) {
 
 interface MintInfoProps {
 	auctionInfo: AuctionInfo;
-	user?: User;
+	user: User | null;
 }
 
 export function MintInfo({ user, auctionInfo: { clearingPrice } }: MintInfoProps) {

--- a/app/routes/beelievers-auction.tsx
+++ b/app/routes/beelievers-auction.tsx
@@ -13,9 +13,9 @@ export async function loader({ params, context, request }: Route.LoaderArgs): Pr
 	const env = context.cloudflare.env;
 	const ctrl = new Controller(env.BeelieversNFT, env.BeelieversD1);
 	const url = new URL(request.url);
+	// TODO: add user param
 	// const suiAddress = url.searchParams.get("suiAddress") ?? undefined;
 	console.log(">>>>> Page Loader handler - params:", params, "url:", url.href);
-	// TODO: add user param
 	return await ctrl.loadPageData();
 }
 
@@ -39,10 +39,8 @@ export default function BeelieversAuctionPage() {
 
 	// TODO: remove this after auction. enforce network change
 	useEffect(() => {
-		if (isProductionMode()) {
-			if (isTestnet) {
-				disconnect();
-			}
+		if (isProductionMode() && isTestnet) {
+			disconnect();
 		}
 	}, [disconnect, isTestnet]);
 

--- a/app/server/BeelieversAuction/controller.server.ts
+++ b/app/server/BeelieversAuction/controller.server.ts
@@ -1,8 +1,8 @@
 import { isValidSuiAddress } from "@mysten/sui/utils";
 import { getFullnodeUrl, SuiClient } from "@mysten/sui/client";
 
-import type { LoaderDataResp, AuctionInfo, User } from "./types";
-import type { RaffleResp, Req, UserResp } from "./jsonrpc";
+import type { LoaderDataResp, AuctionInfo } from "./types";
+import type { QueryRaffleResp, Req, QueryUserResp } from "./jsonrpc";
 import { defaultAuctionInfo, defaultUser, mockRaffleWinners } from "./defaults";
 import { checkTxOnChain, verifySignature } from "./auth.server";
 
@@ -165,7 +165,7 @@ export default class Controller {
 		}
 	}
 
-	async getUserData(userAddr: string): Promise<UserResp> {
+	async getUserData(userAddr: string): Promise<QueryUserResp> {
 		if (!isValidSuiAddress(userAddr)) {
 			return null;
 		}
@@ -177,7 +177,7 @@ export default class Controller {
 		return u;
 	}
 
-	async getRaffle(): Promise<RaffleResp> {
+	async getRaffle(): Promise<QueryRaffleResp> {
 		if (this.isProduction) {
 			return null;
 		}

--- a/app/server/BeelieversAuction/controller.server.ts
+++ b/app/server/BeelieversAuction/controller.server.ts
@@ -2,7 +2,7 @@ import { isValidSuiAddress } from "@mysten/sui/utils";
 import { getFullnodeUrl, SuiClient } from "@mysten/sui/client";
 
 import type { LoaderDataResp, AuctionInfo, User } from "./types";
-import type { RaffleResp, Req } from "./jsonrpc";
+import type { RaffleResp, Req, UserResp } from "./jsonrpc";
 import { defaultAuctionInfo, defaultUser, mockRaffleWinners } from "./defaults";
 import { checkTxOnChain, verifySignature } from "./auth.server";
 
@@ -165,7 +165,7 @@ export default class Controller {
 		}
 	}
 
-	async getUserData(userAddr: string): Promise<User | null> {
+	async getUserData(userAddr: string): Promise<UserResp> {
 		if (!isValidSuiAddress(userAddr)) {
 			return null;
 		}
@@ -177,7 +177,7 @@ export default class Controller {
 		return u;
 	}
 
-	async getRaffle(): Promise<RaffleResp | null> {
+	async getRaffle(): Promise<RaffleResp> {
 		if (this.isProduction) {
 			return null;
 		}

--- a/app/server/BeelieversAuction/jsonrpc.ts
+++ b/app/server/BeelieversAuction/jsonrpc.ts
@@ -31,7 +31,7 @@ export async function makeReq<T>(
 	return fetcher.data;
 }
 
-export type UserResp = User | null;
+export type QueryUserResp = User | null;
 
 export interface RaffleResp_ {
 	winners: Raffle[];
@@ -39,4 +39,4 @@ export interface RaffleResp_ {
 	totalAmount: number;
 }
 
-export type RaffleResp = RaffleResp_ | null;
+export type QueryRaffleResp = RaffleResp_ | null;

--- a/app/server/BeelieversAuction/jsonrpc.ts
+++ b/app/server/BeelieversAuction/jsonrpc.ts
@@ -1,5 +1,5 @@
 import type { FetcherWithComponents } from "react-router";
-import type { Raffle } from "./types";
+import type { Raffle, User } from "./types";
 
 // TODO: make response types
 // TODO: maybe we should extend this by adding network as the top level param?
@@ -31,8 +31,12 @@ export async function makeReq<T>(
 	return fetcher.data;
 }
 
-export interface RaffleResp {
+export type UserResp = User | null;
+
+export interface RaffleResp_ {
 	winners: Raffle[];
 	// total amount in MIST (TODO: need to convert to USD)
 	totalAmount: number;
 }
+
+export type RaffleResp = RaffleResp_ | null;


### PR DESCRIPTION
## Description

Response should be `null` when an item / resource is not found.

## Summary by Sourcery

Standardize fetcher response handling by introducing nullable response types and updating related hooks, controllers, and components to consistently return and handle null when items are not found, as well as refining fetching logic based on auction state.

Bug Fixes:
- Ensure fetchers return null when user or raffle resources are not found
- Delay raffle fetch until the auction state reaches reconciled

Enhancements:
- Define UserResp and RaffleResp nullable types and update controller methods, useFetcher generics, makeReq calls, and component props accordingly
- Condition raffle fetching on reconciled auction state and include auction state in effect dependencies
- Simplify production/testnet disconnect logic into a single conditional
- Refactor component code to default fetcher data to null and relocate auction state calculation