### PR TITLE
refactor: update useEffect usage

### DIFF
--- a/app/pages/BeelieversAuction/MintInfo.tsx
+++ b/app/pages/BeelieversAuction/MintInfo.tsx
@@ -148,14 +148,8 @@ function MintAction({ isWinner, doRefund, hasMinted, setNftId }: MintActionProps
 	const [isMinting, setIsMinting] = useState(false);
 
 	useEffect(() => {
-		const setupKioskInfo = async () => {
-			if (!account) return;
-
-			const result = await initializeKioskInfo(account.address, client, network as Network);
-			setKioskInfo(result);
-		};
-
-		setupKioskInfo();
+		if (!account) return;
+		initializeKioskInfo(account.address, client, network as Network).then(setKioskInfo);
 	}, [account, client, network]);
 
 	const handleMintNFT = async () => {
@@ -341,7 +335,6 @@ export function MintInfo({ user, auctionInfo: { clearingPrice, auctionSize: _auc
 
 	useEffect(() => {
 		if (!account) return;
-
 		queryHasMinted(account.address, client, beelieversMint).then(setHasMinted);
 	}, [account, client, beelieversMint]);
 


### PR DESCRIPTION
## Description

Let's simplify how we use useEffect - in many places, instead of creating additional clousure, we can use what we have and traditional `.then`.

## Summary by Sourcery

Simplify useEffect hooks by removing inline async functions and using Promise.then directly for data fetching

Enhancements:
- Replace async setup functions in useEffect with direct promise.then calls for initializeKioskInfo
- Remove redundant async closures and use .then in useEffect for queryHasMinted