### PR TITLE
feat: move nbtc coin type to config

### DIFF
--- a/app/components/TotalDeposit.tsx
+++ b/app/components/TotalDeposit.tsx
@@ -9,7 +9,6 @@ import { Input } from "./ui/input";
 import { Button } from "./ui/button";
 import { action } from "../config/market.json";
 import { formatNBTC } from "~/lib/denoms";
-import { NBTC_COIN_TYPE } from "~/lib/nbtc";
 import { useCoinBalance } from "~/components/Wallet/SuiWallet/useBalance";
 
 enum MarketIntegration {
@@ -127,7 +126,7 @@ function DepositCard({ title, value }: DepositData) {
 }
 
 export function TotalDeposit() {
-	const { balance: nbtcBalance } = useCoinBalance(NBTC_COIN_TYPE);
+	const { balance: nbtcBalance } = useCoinBalance();
 
 	return (
 		<div className="flex flex-col gap-10 w-full">

--- a/app/components/Wallet/SuiWallet/useBalance.tsx
+++ b/app/components/Wallet/SuiWallet/useBalance.tsx
@@ -1,6 +1,7 @@
 import { useSuiClient, useCurrentAccount } from "@mysten/dapp-kit";
 import { useState, useEffect, useCallback } from "react";
 import { type CoinBalance } from "@mysten/sui/client";
+import { useNetworkVariables } from "~/networkConfig";
 
 export interface UseCoinBalanceResult {
 	balance: bigint;
@@ -11,6 +12,7 @@ export interface UseCoinBalanceResult {
 
 // coin address default to 0x2::sui::SUI if not specified.
 export function useCoinBalance(coinAddr?: string): UseCoinBalanceResult {
+	const { NBTC_COIN_TYPE } = useNetworkVariables();
 	const suiClient = useSuiClient();
 	const account = useCurrentAccount();
 
@@ -35,7 +37,7 @@ export function useCoinBalance(coinAddr?: string): UseCoinBalanceResult {
 
 			const result = await suiClient.getBalance({
 				owner: account.address,
-				coinType: coinAddr,
+				coinType: coinAddr || NBTC_COIN_TYPE,
 			});
 
 			setBalance(result);

--- a/app/components/Wallet/SuiWallet/useBalance.tsx
+++ b/app/components/Wallet/SuiWallet/useBalance.tsx
@@ -12,7 +12,7 @@ export interface UseCoinBalanceResult {
 
 // coin address default to 0x2::sui::SUI if not specified.
 export function useCoinBalance(coinAddr?: string): UseCoinBalanceResult {
-	const { NBTC_COIN_TYPE } = useNetworkVariables();
+	const { nbtcPkgId } = useNetworkVariables();
 	const suiClient = useSuiClient();
 	const account = useCurrentAccount();
 
@@ -37,7 +37,7 @@ export function useCoinBalance(coinAddr?: string): UseCoinBalanceResult {
 
 			const result = await suiClient.getBalance({
 				owner: account.address,
-				coinType: coinAddr || NBTC_COIN_TYPE,
+				coinType: coinAddr || nbtcPkgId,
 			});
 
 			setBalance(result);

--- a/app/config/sui/contracts-mainnet.json
+++ b/app/config/sui/contracts-mainnet.json
@@ -14,5 +14,5 @@
 		"auctionId": "0x161524be15687cca96dec58146568622458905c30479452351f231cac5d64c41"
 	},
 	"accountExplorer": "https://suiscan.xyz/mainnet/account/",
-	"NBTC_COIN_TYPE": "0x5419f6e223f18a9141e91a42286f2783eee27bf2667422c2100afc7b2296731b::nbtc::NBTC"
+	"nbtcPkgId": "0x5419f6e223f18a9141e91a42286f2783eee27bf2667422c2100afc7b2296731b::nbtc::NBTC"
 }

--- a/app/config/sui/contracts-mainnet.json
+++ b/app/config/sui/contracts-mainnet.json
@@ -13,5 +13,6 @@
 		"withdrawFunction": "withdraw",
 		"auctionId": "0x161524be15687cca96dec58146568622458905c30479452351f231cac5d64c41"
 	},
-	"accountExplorer": "https://suiscan.xyz/mainnet/account/"
+	"accountExplorer": "https://suiscan.xyz/mainnet/account/",
+	"NBTC_COIN_TYPE": "0x5419f6e223f18a9141e91a42286f2783eee27bf2667422c2100afc7b2296731b::nbtc::NBTC"
 }

--- a/app/config/sui/contracts-testnet.json
+++ b/app/config/sui/contracts-testnet.json
@@ -14,5 +14,5 @@
 		"auctionId": "0xfda0a2182a1fe1bd620c461a89177802616c3c72ab5ab7f28044b8d393243a7f"
 	},
 	"accountExplorer": "https://suiscan.xyz/testnet/account/",
-	"NBTC_COIN_TYPE": "0x5419f6e223f18a9141e91a42286f2783eee27bf2667422c2100afc7b2296731b::nbtc::NBTC"
+	"nbtcPkgId": "0x5419f6e223f18a9141e91a42286f2783eee27bf2667422c2100afc7b2296731b::nbtc::NBTC"
 }

--- a/app/config/sui/contracts-testnet.json
+++ b/app/config/sui/contracts-testnet.json
@@ -13,5 +13,6 @@
 		"withdrawFunction": "withdraw",
 		"auctionId": "0xfda0a2182a1fe1bd620c461a89177802616c3c72ab5ab7f28044b8d393243a7f"
 	},
-	"accountExplorer": "https://suiscan.xyz/testnet/account/"
+	"accountExplorer": "https://suiscan.xyz/testnet/account/",
+	"NBTC_COIN_TYPE": "0x5419f6e223f18a9141e91a42286f2783eee27bf2667422c2100afc7b2296731b::nbtc::NBTC"
 }

--- a/app/lib/nbtc.ts
+++ b/app/lib/nbtc.ts
@@ -8,8 +8,6 @@ import type { ToastFunction } from "~/hooks/use-toast";
 import type { ExtendedBitcoinNetworkType } from "~/hooks/useBitcoinConfig";
 
 export const PRICE_PER_NBTC_IN_SUI = 25000n;
-export const NBTC_COIN_TYPE =
-	"0x5419f6e223f18a9141e91a42286f2783eee27bf2667422c2100afc7b2296731b::nbtc::NBTC";
 const DUST_THRESHOLD_SATOSHI = 546;
 
 export async function nBTCMintTx(

--- a/app/pages/BuyNBTC/BuyNBTC.tsx
+++ b/app/pages/BuyNBTC/BuyNBTC.tsx
@@ -3,7 +3,6 @@ import { Card, CardContent } from "~/components/ui/card";
 import { WalletContext } from "~/providers/ByieldWalletProvider";
 import { Wallets } from "~/components/Wallet";
 import { useCoinBalance } from "~/components/Wallet/SuiWallet/useBalance";
-import { NBTC_COIN_TYPE } from "~/lib/nbtc";
 import { NBTCBalance } from "~/components/NBTCBalance";
 import { Instructions } from "./Instructions";
 import { BuyNBTCTabContent } from "./BuyNBTCTabContent";
@@ -17,7 +16,7 @@ export function BuyNBTC() {
 	const { mutate: disconnect } = useDisconnectWallet();
 
 	// TODO: it doesn't get automatically refresehed
-	const { balance: nBTCBalance } = useCoinBalance(NBTC_COIN_TYPE);
+	const { balance: nBTCBalance } = useCoinBalance();
 	const { isWalletConnected, suiAddr } = useContext(WalletContext);
 	const isSuiWalletConnected = isWalletConnected(Wallets.SuiWallet);
 	const transactionHistoryLink = `https://suiscan.xyz/testnet/account/${suiAddr}/tx-blocks`;

--- a/app/pages/BuyNBTC/useNBTC.tsx
+++ b/app/pages/BuyNBTC/useNBTC.tsx
@@ -6,7 +6,6 @@ import { useCallback, useContext } from "react";
 import { toast } from "~/hooks/use-toast";
 import type { ToastFunction } from "~/hooks/use-toast";
 import { formatSUI } from "~/lib/denoms";
-import { NBTC_COIN_TYPE } from "~/lib/nbtc";
 import { useCoinBalance } from "~/components/Wallet/SuiWallet/useBalance";
 import { GA_EVENT_NAME, GA_CATEGORY, useGoogleAnalytics } from "~/lib/googleAnalytics";
 import { useNetworkVariables } from "~/networkConfig";
@@ -22,7 +21,11 @@ type Targets = {
 };
 
 // get nBTC coins
-const getNBTCCoins = async (owner: string, client: SuiClient): Promise<PaginatedCoins> => {
+const getNBTCCoins = async (
+	owner: string,
+	client: SuiClient,
+	NBTC_COIN_TYPE: string,
+): Promise<PaginatedCoins> => {
 	return await client.getCoins({
 		owner,
 		coinType: NBTC_COIN_TYPE,
@@ -37,6 +40,7 @@ const createNBTCTxn = async (
 	shouldBuy: boolean,
 	client: SuiClient,
 	nbtcBalance: bigint,
+	NBTC_COIN_TYPE: string,
 ): Promise<Transaction | null> => {
 	const txn = new Transaction();
 	txn.setSender(senderAddress);
@@ -49,7 +53,7 @@ const createNBTCTxn = async (
 			arguments: [txn.object(vaultId), coins],
 		});
 		// merge nbtc coins with the result coin
-		const nbtcCoins = await getNBTCCoins(senderAddress, client);
+		const nbtcCoins = await getNBTCCoins(senderAddress, client, NBTC_COIN_TYPE);
 		const remainingCoins = nbtcCoins.data.map(({ coinObjectId }) => txn.object(coinObjectId));
 		if (remainingCoins.length > 0) txn.mergeCoins(resultCoin, remainingCoins);
 		// Check user have nBTC here, if yes, then we try to merge,
@@ -107,9 +111,9 @@ export const useBuySellNBTC = ({ variant }: NBTCProps): UseNBTCReturn => {
 	const { isWalletConnected } = useContext(WalletContext);
 	const { trackEvent } = useGoogleAnalytics();
 	const isSuiWalletConnected = isWalletConnected(Wallets.SuiWallet);
-	const nbtcBalanceRes = useCoinBalance(NBTC_COIN_TYPE);
+	const nbtcBalanceRes = useCoinBalance();
 	const suiBalanceRes = useCoinBalance();
-	const { nbtcOTC } = useNetworkVariables();
+	const { nbtcOTC, NBTC_COIN_TYPE } = useNetworkVariables();
 
 	const {
 		mutate: signAndExecuteTransaction,
@@ -151,6 +155,7 @@ export const useBuySellNBTC = ({ variant }: NBTCProps): UseNBTCReturn => {
 				shouldBuy,
 				client,
 				nbtcBalanceRes.balance,
+				NBTC_COIN_TYPE,
 			);
 			const label = variant === "BUY" ? `user tried to buy ${formatSUI(amount)} SUI` : "";
 			if (!transaction) {
@@ -189,10 +194,11 @@ export const useBuySellNBTC = ({ variant }: NBTCProps): UseNBTCReturn => {
 			nbtcOTC,
 			shouldBuy,
 			client,
+			nbtcBalanceRes,
+			NBTC_COIN_TYPE,
 			signAndExecuteTransaction,
 			trackEvent,
 			suiBalanceRes,
-			nbtcBalanceRes,
 		],
 	);
 


### PR DESCRIPTION
## Description

Closes: #XXXX

---

### Author Checklist

All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.\_

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  - `fix`: A bug fix
  - `docs`: Documentation only changes
  - `style`: Changes that do not affect the meaning of the code (formatting, missing semi-colons, etc)
  - `refactor`: A code change that neither fixes a bug nor adds a feature
  - `perf`: A code change that improves performance
  - `test`: Adding missing tests or correcting existing tests
  - `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  - `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  - `chore`: Other changes that don't modify src or test files
  - `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Centralize the NBTC coin type into the network configuration and refactor related hooks and components to consume it via useNetworkVariables, removing the hard-coded NBTC_COIN_TYPE export.

Enhancements:
- Introduce NBTC_COIN_TYPE in networkConfig and expose it through useNetworkVariables
- Refactor useNBTC hooks and functions to accept and pass NBTC_COIN_TYPE from config
- Update useCoinBalance to default to the configured NBTC_COIN_TYPE when no coin type is provided

Chores:
- Remove the hard-coded NBTC_COIN_TYPE export from lib/nbtc