### PR TITLE
feat: add copy button UI component

### DIFF
--- a/app/components/ui/CopyButton.tsx
+++ b/app/components/ui/CopyButton.tsx
@@ -1,0 +1,30 @@
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+
+interface CopyButtonProps {
+	text: string;
+}
+
+export function CopyButton({ text }: CopyButtonProps) {
+	const [copied, setCopied] = useState(false);
+
+	const handleCopy = async () => {
+		try {
+			await navigator.clipboard.writeText(text);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		} catch (err) {
+			console.error("Failed to copy text: ", err);
+		}
+	};
+
+	return (
+		<button onClick={handleCopy} className={"hover:bg-primary/10"}>
+			{copied ? (
+				<Check className="text-green-500" size={16} />
+			) : (
+				<Copy size={16} className="text-primary" />
+			)}
+		</button>
+	);
+}

--- a/app/pages/Mint/MintBTCTable.tsx
+++ b/app/pages/Mint/MintBTCTable.tsx
@@ -6,6 +6,7 @@ import { formatBTC } from "~/lib/denoms";
 import { MintingTxStatus, type MintTransaction } from "~/server/Mint/types";
 import { Info } from "lucide-react";
 import { useBitcoinConfig } from "~/hooks/useBitcoinConfig";
+import { CopyButton } from "~/components/ui/CopyButton";
 
 function MintTableTooltip({ tooltip, label }: { tooltip: string; label: string }) {
 	return (
@@ -31,6 +32,7 @@ const createColumns = (confirmationThreshold: number): Column<MintTransaction>[]
 			<Tooltip tooltip={value}>
 				<div className="flex items-center gap-2 font-semibold cursor-pointer">
 					{trimAddress(value)}
+					<CopyButton text={value} />
 				</div>
 			</Tooltip>
 		),
@@ -71,6 +73,7 @@ const createColumns = (confirmationThreshold: number): Column<MintTransaction>[]
 			<Tooltip tooltip={row.original.suiAddress}>
 				<div className="flex items-center space-x-2 font-mono cursor-pointer">
 					<span className="font-mono text-sm">{trimAddress(row.original.suiAddress)}</span>
+					<CopyButton text={row.original.suiAddress} />
 				</div>
 			</Tooltip>
 		),
@@ -84,6 +87,7 @@ const createColumns = (confirmationThreshold: number): Column<MintTransaction>[]
 			<Tooltip tooltip={row.original.suiTxId}>
 				<div className="flex items-center space-x-2 font-mono cursor-pointer">
 					<span className="font-mono text-sm">{trimAddress(row.original.suiTxId)}</span>
+					<CopyButton text={row.original.suiTxId} />
 				</div>
 			</Tooltip>
 		),


### PR DESCRIPTION
## Description

Closes: #XXXX

---

### Author Checklist

All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.\_

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  - `fix`: A bug fix
  - `docs`: Documentation only changes
  - `style`: Changes that do not affect the meaning of the code (formatting, missing semi-colons, etc)
  - `refactor`: A code change that neither fixes a bug nor adds a feature
  - `perf`: A code change that improves performance
  - `test`: Adding missing tests or correcting existing tests
  - `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  - `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  - `chore`: Other changes that don't modify src or test files
  - `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Introduce a reusable CopyButton component for copying text to the clipboard with visual feedback, and integrate it into the MintBTCTable to allow users to easily copy addresses and transaction IDs.

New Features:
- Add CopyButton UI component that writes text to the clipboard and displays a checkmark upon success
- Embed CopyButton in MintBTCTable rows for BTC address, Sui address, and Sui transaction ID fields