### PR TITLE
Feat/display nft after reload

### DIFF
--- a/app/pages/BeelieversAuction/nft.tsx
+++ b/app/pages/BeelieversAuction/nft.tsx
@@ -201,7 +201,11 @@ export const queryNftFromKiosk = async (kioskId: string, client: SuiClient): Pro
 				});
 
 				if (itemObject.data?.type?.includes("mint::")) {
-					return obj.objectId;
+					if (itemObject.data.content && "fields" in itemObject.data.content) {
+						const fields = itemObject.data.content.fields;
+						return fields.id?.id || fields.object_id || obj.objectId;
+					}
+					return obj.objectId; // Fallback to dynamic field ID if content parsing fails
 				}
 			}
 		}


### PR DESCRIPTION
## Description

Closes: #340

## Summary by Sourcery

Enable users to see their minted NFT even after reloading the page by persisting the NFT ID, implement new NFT display and kiosk management components, extend the minting flow to extract and store NFT IDs, and refactor related auction and bidding components to use distinct network configurations.

New Features:
- Persist and display minted NFT across page reloads by storing the NFT ID in localStorage
- Introduce NftDisplay component to fetch and render NFT metadata with a SuiVision link
- Implement kiosk utilities to create, store, retrieve and verify kiosk objects for NFT storage
- Enhance mint flow to create or reuse a kiosk, mint the NFT, extract its ID from transaction results, and show a toast with a SuiVision link

Enhancements:
- Load existing NFT and overall mint status on component mount and show a countdown to mint start in MintInfo
- Refactor network variable usage to separate beelieversAuction and beelieversMint configurations across auction and bid components
- Add utilities for parsing MoveAbort transaction errors and defining Sui environment constants

Build:
- Add @mysten/kiosk dependency and bump @mysten/sui to the latest version