### PR TITLE
refactor: migrate from shadcn select to daisyui select

### DIFF
--- a/app/components/Wallet/SuiWallet/SuiWallet.tsx
+++ b/app/components/Wallet/SuiWallet/SuiWallet.tsx
@@ -33,7 +33,7 @@ function NetWorkOptions() {
 
 	const { network, selectNetwork } = useSuiClientContext();
 	const handleChange = useCallback(
-		(value: SuiNetwork) => {
+		(value: string) => {
 			selectNetwork(value);
 		},
 		[selectNetwork],
@@ -55,8 +55,8 @@ function NetWorkOptions() {
 		<SelectInput
 			options={suiWalletNetworks}
 			placeholder="Select network"
-			onValueChange={handleChange}
-			value={network}
+			onValueChange={(value) => handleChange(value)}
+			defaultValue={network}
 			className="w-full md:w-1/4"
 		/>
 	);
@@ -86,7 +86,7 @@ function Accounts() {
 					},
 				);
 			}}
-			value={currentSelectedAccount?.address}
+			defaultValue={currentSelectedAccount?.address}
 			className="w-full md:w-1/4"
 		/>
 	);

--- a/app/components/Wallet/SuiWallet/SuiWallet.tsx
+++ b/app/components/Wallet/SuiWallet/SuiWallet.tsx
@@ -33,7 +33,7 @@ function NetWorkOptions() {
 
 	const { network, selectNetwork } = useSuiClientContext();
 	const handleChange = useCallback(
-		(value: string) => {
+		(value: SuiNetwork) => {
 			selectNetwork(value);
 		},
 		[selectNetwork],
@@ -41,7 +41,7 @@ function NetWorkOptions() {
 
 	// TODO: remove this after auction. enforce network change
 	const isAuctionPathname = pathname === "/beelievers-auction" && isProductionMode();
-	const networks = useMemo(
+	const suiNetworks: Option<SuiNetwork>[] = useMemo(
 		() =>
 			isAuctionPathname
 				? [{ label: SuiNetworkLabel[SuiNetwork.MainNet], value: SuiNetwork.MainNet }]
@@ -49,14 +49,12 @@ function NetWorkOptions() {
 		[isAuctionPathname],
 	);
 
-	const suiWalletNetworks: Option[] = useMemo(() => networks, [networks]);
-
 	return (
 		<SelectInput
-			options={suiWalletNetworks}
+			options={suiNetworks}
 			placeholder="Select network"
-			onValueChange={(value) => handleChange(value)}
-			value={network}
+			onValueChange={(value: SuiNetwork) => handleChange(value)}
+			value={network as SuiNetwork}
 			className="w-full md:w-1/4"
 		/>
 	);

--- a/app/components/Wallet/SuiWallet/SuiWallet.tsx
+++ b/app/components/Wallet/SuiWallet/SuiWallet.tsx
@@ -56,7 +56,7 @@ function NetWorkOptions() {
 			options={suiWalletNetworks}
 			placeholder="Select network"
 			onValueChange={(value) => handleChange(value)}
-			defaultValue={network}
+			value={network}
 			className="w-full md:w-1/4"
 		/>
 	);
@@ -86,7 +86,7 @@ function Accounts() {
 					},
 				);
 			}}
-			defaultValue={currentSelectedAccount?.address}
+			value={currentSelectedAccount?.address}
 			className="w-full md:w-1/4"
 		/>
 	);

--- a/app/components/Wallet/XverseWallet/XverseWallet.tsx
+++ b/app/components/Wallet/XverseWallet/XverseWallet.tsx
@@ -21,9 +21,9 @@ function NetWorkOptions() {
 	return (
 		<SelectInput
 			options={bitcoinSupportedNetwork}
-			onValueChange={switchNetwork}
+			onValueChange={(value) => switchNetwork(value as ExtendedBitcoinNetworkType)}
 			placeholder="Select network"
-			value={network}
+			defaultValue={network}
 			className="w-full md:w-auto"
 		/>
 	);
@@ -44,7 +44,7 @@ function Accounts() {
 				const account = addressInfo.find((a) => a.address === address);
 				if (account) setCurrentAddress(account);
 			}}
-			value={currentAddress?.address}
+			defaultValue={currentAddress?.address}
 			className="w-full md:w-auto"
 		/>
 	);

--- a/app/components/Wallet/XverseWallet/XverseWallet.tsx
+++ b/app/components/Wallet/XverseWallet/XverseWallet.tsx
@@ -23,7 +23,7 @@ function NetWorkOptions() {
 			options={bitcoinSupportedNetwork}
 			onValueChange={(value) => switchNetwork(value as ExtendedBitcoinNetworkType)}
 			placeholder="Select network"
-			defaultValue={network}
+			value={network}
 			className="w-full md:w-auto"
 		/>
 	);
@@ -44,7 +44,7 @@ function Accounts() {
 				const account = addressInfo.find((a) => a.address === address);
 				if (account) setCurrentAddress(account);
 			}}
-			defaultValue={currentAddress?.address}
+			value={currentAddress?.address}
 			className="w-full md:w-auto"
 		/>
 	);

--- a/app/components/ui/select.tsx
+++ b/app/components/ui/select.tsx
@@ -1,43 +1,54 @@
-import { Select as DaisyUISelect } from "react-daisyui";
-
-interface Option {
+interface Option<T = string> {
 	label: string;
-	value: string;
+	value: T;
 }
 
-interface SelectInputProps {
-	options: Option[];
+interface SelectInputProps<T = string> {
+	options: Option<T>[];
 	placeholder?: string;
-	onValueChange?: (value: string) => void;
+	onValueChange?: (value: T) => void;
 	className?: string;
-	value?: string;
+	value?: T;
 }
 
-export function SelectInput({ options, value, placeholder, onValueChange }: SelectInputProps) {
+function isOptionValueNumberOrString<T>(value: T) {
+	return typeof value === "number" || typeof value === "string";
+}
+
+function SelectInput<T = string>({ options, value, placeholder, onValueChange }: SelectInputProps<T>) {
 	const handleOnChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-		if (onValueChange) onValueChange(event.target.value);
+		if (onValueChange) {
+			const selectedOption = options.find((opt) =>
+				isOptionValueNumberOrString(opt.value) ? opt.value : opt.value === event.target.value,
+			);
+			if (selectedOption) onValueChange(selectedOption.value);
+		}
 	};
 
+	const defaultValue = isOptionValueNumberOrString(value) ? value : String(value);
+	const isThereOptions = options.length;
+
 	return (
-		<DaisyUISelect value={value || "default"} onChange={handleOnChange}>
-			<>
-				{placeholder && (
-					<DaisyUISelect.Option value="default" disabled>
-						{placeholder}
-					</DaisyUISelect.Option>
-				)}
-				{options?.map(({ value, label }) => (
-					<DaisyUISelect.Option
-						key={value}
-						value={value}
-						className="text-white md:text-base text-sm"
+		<select value={defaultValue || "default"} onChange={handleOnChange} className="select">
+			{placeholder && (
+				<option value="default" disabled>
+					{placeholder}
+				</option>
+			)}
+			{isThereOptions ? (
+				options?.map(({ value: optionValue, label }) => (
+					<option
+						key={String(optionValue)}
+						value={isOptionValueNumberOrString(optionValue) ? optionValue : String(optionValue)}
 					>
 						{label}
-					</DaisyUISelect.Option>
-				))}
-			</>
-		</DaisyUISelect>
+					</option>
+				))
+			) : (
+				<option disabled>No options available</option>
+			)}
+		</select>
 	);
 }
 
-export type { Option };
+export { type Option, SelectInput };

--- a/app/components/ui/select.tsx
+++ b/app/components/ui/select.tsx
@@ -14,19 +14,27 @@ interface SelectInputProps {
 }
 
 export function SelectInput({ options, defaultValue, placeholder, onValueChange }: SelectInputProps) {
+	const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+		if (onValueChange) onValueChange(event.target.value);
+	};
+
 	return (
-		<DaisyUISelect value={defaultValue || "default"} onChange={(event) => onValueChange && onValueChange(event.target.value)}>
+		<DaisyUISelect value={defaultValue || "default"} onChange={handleOnChange}>
 			<>
-			{placeholder && (
-				<DaisyUISelect.Option value="default" disabled>
-					{placeholder}
-				</DaisyUISelect.Option>
-			)}
-			{options?.map(({ value, label }) => (
-				<DaisyUISelect.Option key={value} value={value} className="text-white md:text-base text-sm">
-					{label}
-				</DaisyUISelect.Option>
-			))}
+				{placeholder && (
+					<DaisyUISelect.Option value="default" disabled>
+						{placeholder}
+					</DaisyUISelect.Option>
+				)}
+				{options?.map(({ value, label }) => (
+					<DaisyUISelect.Option
+						key={value}
+						value={value}
+						className="text-white md:text-base text-sm"
+					>
+						{label}
+					</DaisyUISelect.Option>
+				))}
 			</>
 		</DaisyUISelect>
 	);

--- a/app/components/ui/select.tsx
+++ b/app/components/ui/select.tsx
@@ -1,177 +1,35 @@
-import * as React from "react";
-import * as SelectPrimitive from "@radix-ui/react-select";
-import { Check, ChevronDown, ChevronUp } from "lucide-react";
-import { cn } from "~/util/tailwind";
-import { twMerge } from "tailwind-merge";
-
-const Select = SelectPrimitive.Root;
-
-const SelectGroup = SelectPrimitive.Group;
-
-const SelectValue = SelectPrimitive.Value;
-
-const SelectTrigger = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.Trigger>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
-	<SelectPrimitive.Trigger
-		ref={ref}
-		className={cn(
-			"flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs ring-offset-background data-placeholder:text-muted-foreground focus:outline-hidden focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
-			className,
-		)}
-		{...props}
-	>
-		{children}
-		<SelectPrimitive.Icon asChild>
-			<ChevronDown className="h-4 w-4 opacity-50 text-white" />
-		</SelectPrimitive.Icon>
-	</SelectPrimitive.Trigger>
-));
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
-
-const SelectScrollUpButton = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
->(({ className, ...props }, ref) => (
-	<SelectPrimitive.ScrollUpButton
-		ref={ref}
-		className={cn("flex cursor-default items-center justify-center py-1", className)}
-		{...props}
-	>
-		<ChevronUp className="h-4 w-4" color="red" />
-	</SelectPrimitive.ScrollUpButton>
-));
-SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
-
-const SelectScrollDownButton = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
->(({ className, ...props }, ref) => (
-	<SelectPrimitive.ScrollDownButton
-		ref={ref}
-		className={cn("flex cursor-default items-center justify-center py-1", className)}
-		{...props}
-	>
-		<ChevronDown className="h-4 w-4" />
-	</SelectPrimitive.ScrollDownButton>
-));
-SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
-
-const SelectContent = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.Content>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = "popper", ...props }, ref) => (
-	<SelectPrimitive.Portal>
-		<SelectPrimitive.Content
-			ref={ref}
-			className={cn(
-				"relative z-50 max-h-(--radix-select-content-available-height) min-w-32 overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-select-content-transform-origin)",
-				position === "popper" &&
-					"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
-				className,
-			)}
-			position={position}
-			{...props}
-		>
-			<SelectScrollUpButton />
-			<SelectPrimitive.Viewport
-				className={cn(
-					"p-1",
-					position === "popper" &&
-						"h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width)",
-				)}
-			>
-				{children}
-			</SelectPrimitive.Viewport>
-			<SelectScrollDownButton />
-		</SelectPrimitive.Content>
-	</SelectPrimitive.Portal>
-));
-SelectContent.displayName = SelectPrimitive.Content.displayName;
-
-const SelectLabel = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.Label>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
->(({ className, ...props }, ref) => (
-	<SelectPrimitive.Label
-		ref={ref}
-		className={cn("px-2 py-1.5 text-sm font-semibold", className)}
-		{...props}
-	/>
-));
-SelectLabel.displayName = SelectPrimitive.Label.displayName;
-
-const SelectItem = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.Item>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
-	<SelectPrimitive.Item
-		ref={ref}
-		className={cn(
-			"relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
-			className,
-		)}
-		{...props}
-	>
-		<span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
-			<SelectPrimitive.ItemIndicator>
-				<Check className="h-4 w-4" />
-			</SelectPrimitive.ItemIndicator>
-		</span>
-		<SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-	</SelectPrimitive.Item>
-));
-SelectItem.displayName = SelectPrimitive.Item.displayName;
-
-const SelectSeparator = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.Separator>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
->(({ className, ...props }, ref) => (
-	<SelectPrimitive.Separator ref={ref} className={cn("-mx-1 my-1 h-px bg-muted", className)} {...props} />
-));
-SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+import { Select as DaisyUISelect } from "react-daisyui";
 
 interface Option {
 	label: string;
 	value: string;
 }
 
-interface SelectInputProps extends SelectPrimitive.SelectProps {
+interface SelectInputProps {
 	options: Option[];
-	placeholder: string;
+	placeholder?: string;
+	onValueChange?: (value: string) => void;
 	className?: string;
+	defaultValue?: string;
 }
 
-function SelectInput({ options, placeholder, className, ...rest }: SelectInputProps) {
+export function SelectInput({ options, defaultValue, placeholder, onValueChange }: SelectInputProps) {
 	return (
-		<Select {...rest}>
-			<SelectTrigger className={twMerge("bg-[#222529] w-1/4 h-10 rounded-[100px]", className)}>
-				<SelectValue placeholder={placeholder} />
-			</SelectTrigger>
-			<SelectContent>
-				{options?.map(({ value, label }) => (
-					<SelectItem key={value} value={value} className="text-white md:text-base text-sm">
-						{label}
-					</SelectItem>
-				))}
-			</SelectContent>
-		</Select>
+		<DaisyUISelect value={defaultValue || "default"} onChange={(event) => onValueChange && onValueChange(event.target.value)}>
+			<>
+			{placeholder && (
+				<DaisyUISelect.Option value="default" disabled>
+					{placeholder}
+				</DaisyUISelect.Option>
+			)}
+			{options?.map(({ value, label }) => (
+				<DaisyUISelect.Option key={value} value={value} className="text-white md:text-base text-sm">
+					{label}
+				</DaisyUISelect.Option>
+			))}
+			</>
+		</DaisyUISelect>
 	);
 }
-
-export {
-	Select,
-	SelectGroup,
-	SelectValue,
-	SelectTrigger,
-	SelectContent,
-	SelectLabel,
-	SelectItem,
-	SelectSeparator,
-	SelectScrollUpButton,
-	SelectScrollDownButton,
-	SelectInput,
-};
 
 export type { Option };

--- a/app/components/ui/select.tsx
+++ b/app/components/ui/select.tsx
@@ -10,16 +10,16 @@ interface SelectInputProps {
 	placeholder?: string;
 	onValueChange?: (value: string) => void;
 	className?: string;
-	defaultValue?: string;
+	value?: string;
 }
 
-export function SelectInput({ options, defaultValue, placeholder, onValueChange }: SelectInputProps) {
-	const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+export function SelectInput({ options, value, placeholder, onValueChange }: SelectInputProps) {
+	const handleOnChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
 		if (onValueChange) onValueChange(event.target.value);
 	};
 
 	return (
-		<DaisyUISelect value={defaultValue || "default"} onChange={handleOnChange}>
+		<DaisyUISelect value={value || "default"} onChange={handleOnChange}>
 			<>
 				{placeholder && (
 					<DaisyUISelect.Option value="default" disabled>

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,6 @@
         "@mysten/kiosk": "^0.13.0",
         "@mysten/sui": "^1.38.0",
         "@radix-ui/react-dialog": "^1.1.14",
-        "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.2.3",
         "@react-router/cloudflare": "^7.6.3",
         "@react-router/remix-routes-option-adapter": "^7.7.1",
@@ -380,8 +379,6 @@
 
     "@poppinss/exception": ["@poppinss/exception@1.2.2", "", {}, "sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg=="],
 
-    "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
-
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
 
     "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
@@ -418,8 +415,6 @@
 
     "@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA=="],
 
-    "@radix-ui/react-select": ["@radix-ui/react-select@2.2.6", "", { "dependencies": { "@radix-ui/number": "1.1.1", "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ=="],
-
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
@@ -432,13 +427,9 @@
 
     "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
 
-    "@radix-ui/react-use-previous": ["@radix-ui/react-use-previous@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ=="],
-
     "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.1", "", { "dependencies": { "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w=="],
 
     "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ=="],
-
-    "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
 		"@mysten/kiosk": "^0.13.0",
 		"@mysten/sui": "^1.38.0",
 		"@radix-ui/react-dialog": "^1.1.14",
-		"@radix-ui/react-select": "^2.2.5",
 		"@radix-ui/react-slot": "^1.2.3",
 		"@react-router/cloudflare": "^7.6.3",
 		"@react-router/remix-routes-option-adapter": "^7.7.1",


### PR DESCRIPTION
## Description

Closes: #XXXX

---

### Author Checklist

All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.\_

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  - `fix`: A bug fix
  - `docs`: Documentation only changes
  - `style`: Changes that do not affect the meaning of the code (formatting, missing semi-colons, etc)
  - `refactor`: A code change that neither fixes a bug nor adds a feature
  - `perf`: A code change that improves performance
  - `test`: Adding missing tests or correcting existing tests
  - `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  - `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  - `chore`: Other changes that don't modify src or test files
  - `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Replace the custom Radix-based select components with DaisyUI’s Select to streamline dropdowns and remove redundant code.

Enhancements:
- Refactor the SelectInput component to wrap react-daisyui’s Select instead of Radix UI primitives
- Update wallet components to use the new SelectInput API (defaultValue and onValueChange)

Build:
- Remove @radix-ui/react-select from the project dependencies