### PR TITLE
feat: support scripts in OP_RETURN

### DIFF
--- a/app/lib/opreturn-scripts.test.ts
+++ b/app/lib/opreturn-scripts.test.ts
@@ -1,0 +1,158 @@
+import { describe, test, expect } from "vitest";
+
+const MINT_NBTC_ACTION = "0";
+const FUTURE_ACTION = "1";
+
+/**
+ * Creates an OP_RETURN script string for Bitcoin transactions
+ * Format: [action_type] [sui_address]
+ *
+ * @param actionType - '0' for mint nBTC action, '1' for future actions
+ * @param suiAddress - Full SUI address with 0x prefix
+ * @returns OP_RETURN script string (action type + space + full SUI address)
+ */
+function createOpReturnScript(
+	actionType: typeof MINT_NBTC_ACTION | typeof FUTURE_ACTION,
+	suiAddress: string,
+): string {
+	return `${actionType} ${suiAddress}`;
+}
+
+describe("OP_RETURN Script Functions", () => {
+	describe("createOpReturnScript", () => {
+		test("should create mint action script with 0x prefix", () => {
+			const testAddress =
+				"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+			const result = createOpReturnScript(MINT_NBTC_ACTION, testAddress);
+
+			expect(result).toBe(
+				"0 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			);
+			expect(result.length).toBe(68);
+			expect(result.startsWith("0 0x")).toBe(true);
+		});
+
+		test("should create future action script with 0x prefix", () => {
+			const testAddress =
+				"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+			const result = createOpReturnScript(FUTURE_ACTION, testAddress);
+
+			expect(result).toBe(
+				"1 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			);
+			expect(result.length).toBe(68);
+			expect(result.startsWith("1 0x")).toBe(true);
+		});
+
+		test("should create mint action script without 0x prefix", () => {
+			const testAddress = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+			const result = createOpReturnScript(MINT_NBTC_ACTION, testAddress);
+
+			expect(result).toBe(
+				"0 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			);
+			expect(result.length).toBe(66);
+			expect(result.startsWith("0 ")).toBe(true);
+		});
+
+		test("should handle uppercase hex addresses", () => {
+			const testAddress =
+				"0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF";
+			const result = createOpReturnScript(MINT_NBTC_ACTION, testAddress);
+
+			expect(result).toBe(
+				"0 0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+			);
+			expect(result.startsWith("0 0x")).toBe(true);
+		});
+
+		test("should handle mixed case 0x prefix", () => {
+			const testAddress =
+				"0X1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+			const result = createOpReturnScript(MINT_NBTC_ACTION, testAddress);
+
+			expect(result).toBe(
+				"0 0X1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			);
+			expect(result.startsWith("0 0X")).toBe(true);
+		});
+
+		test("should handle short addresses", () => {
+			const testAddress = "0x123";
+			const result = createOpReturnScript(MINT_NBTC_ACTION, testAddress);
+
+			expect(result).toBe("0 0x123");
+			expect(result.startsWith("0 0x")).toBe(true);
+		});
+	});
+
+	describe("Action Type Constants", () => {
+		test("should have correct action type values", () => {
+			expect(MINT_NBTC_ACTION).toBe("0");
+			expect(FUTURE_ACTION).toBe("1");
+		});
+	});
+
+	describe("OP_RETURN Script Format Validation", () => {
+		test("should create valid format for parsing", () => {
+			const testAddress =
+				"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+			const script = createOpReturnScript(MINT_NBTC_ACTION, testAddress);
+
+			const parts = script.split(" ");
+			expect(parts.length).toBe(2);
+
+			const actionType = parts[0];
+			const suiAddress = parts[1];
+
+			expect(actionType).toBe(MINT_NBTC_ACTION);
+			expect(suiAddress).toBe(
+				"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			);
+			expect(suiAddress.length).toBe(66);
+
+			expect(suiAddress.startsWith("0x")).toBe(true);
+			expect(/^0x[0-9a-fA-F]{64}$/.test(suiAddress)).toBe(true);
+		});
+
+		test("should parse script format correctly", () => {
+			const mintScript = createOpReturnScript(
+				MINT_NBTC_ACTION,
+				"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			);
+			const futureScript = createOpReturnScript(
+				FUTURE_ACTION,
+				"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			);
+
+			const mintParts = mintScript.split(" ");
+			expect(mintParts[0]).toBe(MINT_NBTC_ACTION);
+			expect(mintParts[1]).toBe(
+				"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			);
+
+			const futureParts = futureScript.split(" ");
+			expect(futureParts[0]).toBe(FUTURE_ACTION);
+			expect(futureParts[1]).toBe(
+				"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			);
+		});
+
+		test("should validate parsing of different action types", () => {
+			const testAddress =
+				"0xabc123def456abc123def456abc123def456abc123def456abc123def456abc123";
+
+			const mintScript = createOpReturnScript(MINT_NBTC_ACTION, testAddress);
+			const mintParts = mintScript.split(" ");
+			expect(mintParts.length).toBe(2);
+			expect(mintParts[0]).toBe("0");
+			expect(mintParts[1]).toBe(testAddress);
+
+			const futureScript = createOpReturnScript(FUTURE_ACTION, testAddress);
+			const futureParts = futureScript.split(" ");
+			expect(futureParts.length).toBe(2);
+			expect(futureParts[0]).toBe("1");
+			expect(futureParts[1]).toBe(testAddress);
+		});
+	});
+});

--- a/app/pages/Mint/MintBTC.tsx
+++ b/app/pages/Mint/MintBTC.tsx
@@ -11,7 +11,7 @@ import { Wallets } from "~/components/Wallet";
 import { FormNumericInput } from "../../components/form/FormNumericInput";
 import { NumericFormat } from "react-number-format";
 import { BTC, formatBTC, parseBTC } from "~/lib/denoms";
-import { nBTCMintTx } from "~/lib/nbtc";
+import { nBTCMintTx, MINT_NBTC_ACTION, createOpReturnScript } from "~/lib/nbtc";
 import { Check } from "lucide-react";
 import { classNames } from "~/util/tailwind";
 import { isValidSuiAddress } from "@mysten/sui/utils";
@@ -65,12 +65,7 @@ function TransactionStatus({ SuiAddress, txId, handleRetry }: TransactionStatusP
 	);
 }
 
-function formatSuiAddress(suiAddress: string) {
-	if (suiAddress.toLowerCase().startsWith("0x")) {
-		return suiAddress.substring(2);
-	}
-	return suiAddress;
-}
+// Removed formatSuiAddressForMint function using createOpReturnScript from nbtc.ts
 
 const PERCENTAGES = [
 	{
@@ -163,7 +158,7 @@ export function MintBTC() {
 			const response = await nBTCMintTx(
 				currentAddress,
 				Number(parseBTC(numberOfBTC)),
-				formatSuiAddress(suiAddress),
+				createOpReturnScript(MINT_NBTC_ACTION, suiAddress),
 				network,
 				bitcoinConfig.nBTC.depositAddress,
 			);


### PR DESCRIPTION
Add action type prefix format: '[action_type] [sui_address]'
- 0: mint nBTC, 1: future actions
- Preserve full SUI address with space separator
- Add createOpReturnScript() helper and tests

## Description

Closes: #186 

---

### Author Checklist

All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.\_

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  - `fix`: A bug fix
  - `docs`: Documentation only changes
  - `style`: Changes that do not affect the meaning of the code (formatting, missing semi-colons, etc)
  - `refactor`: A code change that neither fixes a bug nor adds a feature
  - `perf`: A code change that improves performance
  - `test`: Adding missing tests or correcting existing tests
  - `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  - `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  - `chore`: Other changes that don't modify src or test files
  - `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
