### PR TITLE
feat: display mint nBTC fee

### DIFF
--- a/app/config/bitcoin-devnet.json
+++ b/app/config/bitcoin-devnet.json
@@ -3,7 +3,7 @@
 	"confirmationThreshold": 6,
 	"nBTC": {
 		"depositAddress": "tb1qjgqhst2hlgjkh36pg6r3hdnz7zvurafe9h5lkx",
-		"mintingFeeNSats": 5
+		"mintingFee": 5
 	},
 	"indexerUrl": "",
 	"btcRPCUrl": "http://142.93.46.134:3002"

--- a/app/config/bitcoin-devnet.json
+++ b/app/config/bitcoin-devnet.json
@@ -2,7 +2,8 @@
 	"bitcoinBroadcastLink": "",
 	"confirmationThreshold": 6,
 	"nBTC": {
-		"depositAddress": "tb1qjgqhst2hlgjkh36pg6r3hdnz7zvurafe9h5lkx"
+		"depositAddress": "tb1qjgqhst2hlgjkh36pg6r3hdnz7zvurafe9h5lkx",
+		"mintingFeeNSats": 5
 	},
 	"indexerUrl": "",
 	"btcRPCUrl": "http://142.93.46.134:3002"

--- a/app/config/bitcoin-mainnet.json
+++ b/app/config/bitcoin-mainnet.json
@@ -2,7 +2,8 @@
 	"bitcoinBroadcastLink": "https://mempool.space/tx/",
 	"confirmationThreshold": 6,
 	"nBTC": {
-		"depositAddress": "tb1qjgqhst2hlgjkh36pg6r3hdnz7zvurafe9h5lkx"
+		"depositAddress": "tb1qjgqhst2hlgjkh36pg6r3hdnz7zvurafe9h5lkx",
+		"mintingFeeNSats": 5
 	},
 	"indexerUrl": "",
 	"btcRPCUrl": ""

--- a/app/config/bitcoin-mainnet.json
+++ b/app/config/bitcoin-mainnet.json
@@ -3,7 +3,7 @@
 	"confirmationThreshold": 6,
 	"nBTC": {
 		"depositAddress": "tb1qjgqhst2hlgjkh36pg6r3hdnz7zvurafe9h5lkx",
-		"mintingFeeNSats": 5
+		"mintingFee": 5
 	},
 	"indexerUrl": "",
 	"btcRPCUrl": ""

--- a/app/pages/Mint/MintBTC.tsx
+++ b/app/pages/Mint/MintBTC.tsx
@@ -95,10 +95,10 @@ function Percentage({ onChange }: { onChange: (value: number) => void }) {
 }
 
 interface FeeProps {
-	mintingFeeNSats: bigint;
+	mintingFee: bigint;
 }
 
-function Fee({ mintingFeeNSats }: FeeProps) {
+function Fee({ mintingFee }: FeeProps) {
 	return (
 		<div className="card card-border bg-base-300">
 			<div className="card-body">
@@ -106,7 +106,7 @@ function Fee({ mintingFeeNSats }: FeeProps) {
 					<span>Minting Fee</span>
 					<div className="tooltip" data-tip="1 nSats = 0.00000001 nBTC">
 						<span className="cursor-help">
-							{mintingFeeNSats} nSats ({formatNBTC(mintingFeeNSats)} nBTC)
+							{mintingFee} nSats ({formatNBTC(mintingFee)} nBTC)
 						</span>
 					</div>
 				</div>
@@ -219,9 +219,7 @@ export function MintBTC() {
 								},
 							}}
 						/>
-						{bitcoinConfig.nBTC && (
-							<Fee mintingFeeNSats={BigInt(bitcoinConfig?.nBTC?.mintingFeeNSats)} />
-						)}
+						{bitcoinConfig.nBTC && <Fee mintingFee={BigInt(bitcoinConfig?.nBTC?.mintingFee)} />}
 						{isBitCoinWalletConnected ? (
 							<button
 								type="submit"

--- a/app/pages/Mint/MintBTC.tsx
+++ b/app/pages/Mint/MintBTC.tsx
@@ -6,8 +6,7 @@ import { useContext, useEffect, useState } from "react";
 import { WalletContext } from "~/providers/ByieldWalletProvider";
 import { Wallets } from "~/components/Wallet";
 import { FormNumericInput } from "../../components/form/FormNumericInput";
-import { NumericFormat } from "react-number-format";
-import { BTC, formatBTC, parseBTC } from "~/lib/denoms";
+import { BTC, formatBTC, parseBTC, formatNBTC } from "~/lib/denoms";
 import { nBTCMintTx } from "~/lib/nbtc";
 import { BitcoinIcon, Check } from "lucide-react";
 import { buttonEffectClasses, classNames } from "~/util/tailwind";
@@ -96,21 +95,20 @@ function Percentage({ onChange }: { onChange: (value: number) => void }) {
 }
 
 interface FeeProps {
-	feeInSatoshi: bigint;
-	youReceive: string;
+	mintingFeeNSats: bigint;
 }
 
-function Fee({ feeInSatoshi, youReceive }: FeeProps) {
+function Fee({ mintingFeeNSats }: FeeProps) {
 	return (
-		<div className="card p-4 rounded-2xl h-24">
-			<div className="card-body flex flex-col justify-between h-full p-0">
-				<div className="flex justify-between">
-					<p className="text-gray-400">Fixed Fee</p>
-					<NumericFormat displayType="text" value={formatBTC(feeInSatoshi)} suffix=" Satoshi" />
-				</div>
-				<div className="flex justify-between">
-					<p className="text-gray-400">You Receive</p>
-					<NumericFormat displayType="text" value={youReceive} suffix=" nBTC" />
+		<div className="card card-border bg-base-300">
+			<div className="card-body">
+				<div className="flex justify-between text-sm">
+					<span>Minting Fee</span>
+					<div className="tooltip" data-tip="1 nSats = 0.00000001 nBTC">
+						<span className="cursor-help">
+							{mintingFeeNSats} nSats ({formatNBTC(mintingFeeNSats)} nBTC)
+						</span>
+					</div>
 				</div>
 			</div>
 		</div>
@@ -221,6 +219,9 @@ export function MintBTC() {
 								},
 							}}
 						/>
+						{bitcoinConfig.nBTC && (
+							<Fee mintingFeeNSats={BigInt(bitcoinConfig?.nBTC?.mintingFeeNSats)} />
+						)}
 						{isBitCoinWalletConnected ? (
 							<button
 								type="submit"


### PR DESCRIPTION
## Description

Closes: #XXXX

---

### Author Checklist

All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.\_

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  - `fix`: A bug fix
  - `docs`: Documentation only changes
  - `style`: Changes that do not affect the meaning of the code (formatting, missing semi-colons, etc)
  - `refactor`: A code change that neither fixes a bug nor adds a feature
  - `perf`: A code change that improves performance
  - `test`: Adding missing tests or correcting existing tests
  - `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  - `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  - `chore`: Other changes that don't modify src or test files
  - `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Display the nBTC minting fee in the MintBTC flow and update network configuration for Regtest.

New Features:
- Show minting fee as nSats and formatted nBTC with tooltip on the MintBTC page

Enhancements:
- Simplify and rename the Fee component to use a single mintingFeeNSats prop
- Conditionally render the Fee component only when nBTC config is available

Chores:
- Merge devnet config variables into the Regtest network settings in useBitcoinConfig