### PR TITLE
fix: prevent duplicate balance error toasts in useXverseWallet

### DIFF
--- a/app/components/Wallet/XverseWallet/useWallet.tsx
+++ b/app/components/Wallet/XverseWallet/useWallet.tsx
@@ -74,7 +74,6 @@ export const useXverseWallet = () => {
 				setBalance(response.result.total);
 				hasFetchedBalanceSuccessfullyRef.current = true;
 			} else {
-				// Only show an error if we never had a successful balance
 				if (!hasFetchedBalanceSuccessfullyRef.current) {
 					toast({
 						title: "Balance",


### PR DESCRIPTION
Added a ref to manage toast notifications for balance fetch failures, ensuring that error messages are only shown once until a successful fetch occurs. This change improves user experience by reducing notification spam during transient issues.

## Description

Closes: #433 

### Summary
1. Added a ref-guard to throttle balance error toasts so the message is shown only once until a successful fetch occurs. This avoids notification spam during transient RPC or wallet hiccups.
### Context
1. Repro reports showed repeated “Failed to get the balance” toasts during intermittent failures.
2. Root cause was an effect feedback loop plus unthrottled error handling.
### We now:
- Remove network from the wallet status effect deps to avoid loops.
- Gate error toasts behind a useRef that resets on success or disconnect.


<img width="2547" height="946" alt="image" src="https://github.com/user-attachments/assets/f73547e6-6138-49dd-8a1b-43dc5d3d5aa2" />


Signed-off-by: George <georgebak2182@gmail.com>

## Summary by Sourcery

Use a ref guard to ensure balance error toasts are shown only once until the next successful fetch or disconnect, and adjust effect dependencies to prevent unintended feedback loops

Bug Fixes:
- Throttle balance fetch error toasts to prevent repeated "Failed to get the balance" notifications

Enhancements:
- Reset the error-spam guard on a successful balance fetch or wallet disconnect
- Remove `network` from the wallet status effect dependencies to avoid feedback loops