### PR TITLE
fix: 433 toast spam failed get balance

### DIFF
--- a/app/components/Wallet/XverseWallet/useWallet.tsx
+++ b/app/components/Wallet/XverseWallet/useWallet.tsx
@@ -64,24 +64,24 @@ export const useXverseWallet = () => {
 	const [balance, setBalance] = useState<string>();
 	// TODO: Default bitcoin network on connection is Testnet4
 	const [network, setNetwork] = useState<ExtendedBitcoinNetworkType>(ExtendedBitcoinNetworkType.Testnet4);
-	// Prevent repeated toasts when balance fetch fails due to a transient issue
-	const hasShownBalanceErrorRef = useRef<boolean>(false);
+	// Only toast on failure if we have not yet successfully fetched a balance
+	const hasFetchedBalanceSuccessfullyRef = useRef<boolean>(false);
 
 	const getBalance = useCallback(async () => {
 		try {
 			const response = await Wallet.request(getBalanceMethodName, null);
 			if (response.status === "success") {
 				setBalance(response.result.total);
-				// Reset the error flag on success so future failures can notify once
-				hasShownBalanceErrorRef.current = false;
+				// Mark that we have a successful balance at least once
+				hasFetchedBalanceSuccessfullyRef.current = true;
 			} else {
-				if (!hasShownBalanceErrorRef.current) {
+				// Only show an error if we never had a successful balance
+				if (!hasFetchedBalanceSuccessfullyRef.current) {
 					toast({
 						title: "Balance",
 						description: "Failed to get the balance",
 						variant: "destructive",
 					});
-					hasShownBalanceErrorRef.current = true;
 				}
 			}
 		} catch (err) {
@@ -128,8 +128,8 @@ export const useXverseWallet = () => {
 				setAddressInfo([]);
 				setCurrentAddress(null);
 				setBalance(undefined);
-				// Reset error spam guard on disconnect
-				hasShownBalanceErrorRef.current = false;
+				// Reset session success marker on disconnect
+				hasFetchedBalanceSuccessfullyRef.current = false;
 			}
 		}
 		getWalletStatus();

--- a/app/components/Wallet/XverseWallet/useWallet.tsx
+++ b/app/components/Wallet/XverseWallet/useWallet.tsx
@@ -133,9 +133,8 @@ export const useXverseWallet = () => {
 			}
 		}
 		getWalletStatus();
-		// Note: do not depend on `network` here to avoid feedback loops that
-		// can repeatedly trigger balance fetches and spam toasts on failure.
-	}, [getAddresses, getBalance, getNetworkStatus, isBitCoinWalletConnected]);
+		// Re-fetch on `network` or `currentAddress` change as well as connect state
+	}, [getAddresses, getBalance, getNetworkStatus, isBitCoinWalletConnected, network, currentAddress]);
 
 	const disconnectWallet = useCallback(async () => {
 		try {
@@ -181,6 +180,7 @@ export const useXverseWallet = () => {
 		currentAddress,
 		addressInfo,
 		setCurrentAddress,
+		refreshBalance: getBalance,
 		disconnectWallet,
 		switchNetwork,
 	};


### PR DESCRIPTION
## Description

Closes: #433 

## Summary
- Prevents toast spam and ensures balance stays accurate:
- Refetch balance automatically when network or currentAddress changes.
- Provide refreshBalance for post-transaction updates.
- Show “Failed to get network status” toast only before the first successful network fetch; reset on disconnect.
- Show balance failure toast only before the first successful balance fetch in a session.
## Changes
- app/components/Wallet/XverseWallet/useWallet.tsx
- Fetch addresses → network → balance on connect.
- Refetch balance when network/currentAddress change.
- Add refreshBalance for manual refetches.
- Add lightweight guards to avoid repeated network/balance error toasts.
- Keep dependencies minimal to avoid feedback loops.


Signed-off-by: George <georgebak2182@gmail.com>

## Summary by Sourcery

Prevent toast spam on balance and network errors by showing error toasts only before first success, auto-refetch balance on relevant changes, reset markers on disconnect, and expose refreshBalance for manual updates

New Features:
- Expose refreshBalance callback for manual balance updates
- Automatically refetch balance when network or current address changes while connected

Enhancements:
- Suppress repeated network and balance error toasts by tracking the first successful fetch
- Reset network and balance success markers on wallet disconnect