### PR TITLE
fix: reduced useBalance calls

### DIFF
--- a/app/components/Wallet/SuiWallet/useBalance.tsx
+++ b/app/components/Wallet/SuiWallet/useBalance.tsx
@@ -23,7 +23,6 @@ async function fetchBalance(
 }
 
 // Coin address is a coin package ID followed by the type. Default to 0x2::sui::SUI.
-// Backward compatible: accepts either a full coin type string, "NBTC", or "SUI"/undefined for SUI.
 export function useCoinBalance(coinOrVariant?: string): UseCoinBalanceResult {
 	const suiClient = useSuiClient();
 	const account = useCurrentAccount();

--- a/app/pages/BuyNBTC/BuyNBTC.tsx
+++ b/app/pages/BuyNBTC/BuyNBTC.tsx
@@ -8,8 +8,7 @@ import { BuyNBTCTabContent } from "./BuyNBTCTabContent";
 import { SellNBTCTabContent } from "./SellNBTCTabContent";
 import { ArrowUpRight } from "lucide-react";
 import { useDisconnectWallet, useSuiClientContext } from "@mysten/dapp-kit";
-import { useNetworkVariables } from "~/networkConfig";
-import type { BalanceProps } from "~/types/balance";
+import type { UseCoinBalanceResult } from "~/components/Wallet/SuiWallet/useBalance";
 
 export function BuyNBTC() {
 	const { network } = useSuiClientContext();
@@ -70,7 +69,10 @@ const renderTabHeader = (title: string, checked = false) => (
 	/>
 );
 
-type BuyNBTCTabsProps = BalanceProps;
+type BuyNBTCTabsProps = {
+	nbtcBalanceRes: UseCoinBalanceResult;
+	suiBalanceRes: UseCoinBalanceResult;
+};
 
 const BuyNBTCTabs = ({ nbtcBalanceRes, suiBalanceRes }: BuyNBTCTabsProps) => (
 	<div className="tabs tabs-boxed rounded-full p-1">

--- a/app/pages/BuyNBTC/BuyNBTCTabContent.tsx
+++ b/app/pages/BuyNBTC/BuyNBTCTabContent.tsx
@@ -11,7 +11,7 @@ import { classNames } from "~/util/tailwind";
 import { SUIIcon } from "~/components/icons";
 import { useBuySellNBTC } from "./useNBTC";
 import { LoadingSpinner } from "~/components/LoadingSpinner";
-import type { BalanceProps } from "~/types/balance";
+import type { UseCoinBalanceResult } from "~/components/Wallet/SuiWallet/useBalance";
 
 const BUY_NBTC_GAS = parseSUI("0.01");
 
@@ -47,7 +47,10 @@ interface BuyNBTCForm {
 	suiAmount: string;
 }
 
-type BuyNBTCTabContentProps = BalanceProps;
+type BuyNBTCTabContentProps = {
+	nbtcBalanceRes: UseCoinBalanceResult;
+	suiBalanceRes: UseCoinBalanceResult;
+};
 
 export function BuyNBTCTabContent({ nbtcBalanceRes, suiBalanceRes }: BuyNBTCTabContentProps) {
 	const {

--- a/app/pages/BuyNBTC/SellNBTCTabContent.tsx
+++ b/app/pages/BuyNBTC/SellNBTCTabContent.tsx
@@ -11,7 +11,7 @@ import { FormNumericInput } from "~/components/form/FormNumericInput";
 import { classNames } from "~/util/tailwind";
 import { PRICE_PER_NBTC_IN_SUI } from "~/lib/nbtc";
 import { LoadingSpinner } from "~/components/LoadingSpinner";
-import type { BalanceProps } from "~/types/balance";
+import type { UseCoinBalanceResult } from "~/components/Wallet/SuiWallet/useBalance";
 
 interface NBTCRightAdornmentProps {
 	maxNBTCAmount: bigint;
@@ -47,7 +47,10 @@ interface SellNBTCForm {
 	nBTCAmount: string;
 }
 
-type SellNBTCTabContentProps = BalanceProps;
+type SellNBTCTabContentProps = {
+	nbtcBalanceRes: UseCoinBalanceResult;
+	suiBalanceRes: UseCoinBalanceResult;
+};
 
 export function SellNBTCTabContent({ nbtcBalanceRes, suiBalanceRes }: SellNBTCTabContentProps) {
 	const {

--- a/app/pages/BuyNBTC/useNBTC.tsx
+++ b/app/pages/BuyNBTC/useNBTC.tsx
@@ -10,7 +10,7 @@ import { GA_EVENT_NAME, GA_CATEGORY, useGoogleAnalytics } from "~/lib/googleAnal
 import { useNetworkVariables } from "~/networkConfig";
 import { WalletContext } from "~/providers/ByieldWalletProvider";
 import { Wallets } from "~/components/Wallet";
-import type { BalanceProps } from "~/types/balance";
+import type { UseCoinBalanceResult } from "~/components/Wallet/SuiWallet/useBalance";
 
 import { moveCallTarget, type NbtcOtcCfg } from "~/config/sui/contracts-config";
 
@@ -89,8 +89,10 @@ interface UseNBTCReturn {
 	isSuiWalletConnected: boolean;
 }
 
-interface NBTCProps extends BalanceProps {
+interface NBTCProps {
 	variant: "BUY" | "SELL";
+	nbtcBalanceRes: UseCoinBalanceResult;
+	suiBalanceRes: UseCoinBalanceResult;
 }
 
 export const useBuySellNBTC = ({ variant, nbtcBalanceRes, suiBalanceRes }: NBTCProps): UseNBTCReturn => {
@@ -179,6 +181,7 @@ export const useBuySellNBTC = ({ variant, nbtcBalanceRes, suiBalanceRes }: NBTCP
 			variant,
 			account,
 			nbtcOTC,
+			nbtc,
 			shouldBuy,
 			client,
 			nbtcBalanceRes,

--- a/app/types/balance.ts
+++ b/app/types/balance.ts
@@ -1,6 +1,0 @@
-import type { UseCoinBalanceResult } from "~/components/Wallet/SuiWallet/useBalance";
-
-export interface BalanceProps {
-	nbtcBalanceRes: UseCoinBalanceResult;
-	suiBalanceRes: UseCoinBalanceResult;
-}


### PR DESCRIPTION


## Description

Closes: #449 

---

### Author Checklist

All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.\_

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  - `fix`: A bug fix
  - `docs`: Documentation only changes
  - `style`: Changes that do not affect the meaning of the code (formatting, missing semi-colons, etc)
  - `refactor`: A code change that neither fixes a bug nor adds a feature
  - `perf`: A code change that improves performance
  - `test`: Adding missing tests or correcting existing tests
  - `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  - `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  - `chore`: Other changes that don't modify src or test files
  - `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Centralize coin balance fetching in the parent BuyNBTC component and propagate results and coin identifier down to tabs and hooks to avoid redundant balance calls and properly type the props.

Bug Fixes:
- Change default network selection in root from localnet to testnet

Enhancements:
- Move useCoinBalance hooks for SUI and nbtc coins into BuyNBTC and pass results via a new BalanceProps interface
- Introduce BalanceProps type and update BuyNBTCTabs, BuyNBTCTabContent, SellNBTCTabContent, and useBuySellNBTC to accept and use propagated balance data and coin identifier