### PR TITLE
fix: await post mint tx before fetch

### DIFF
--- a/app/pages/Mint/MintBTC.tsx
+++ b/app/pages/Mint/MintBTC.tsx
@@ -166,12 +166,12 @@ export function MintBTC({ fetchMintTxs }: MintBTCProps) {
 				const txid = response.result.txid;
 				setTxId(txid);
 				setShowConfirmationModal(true);
-				makeReq(postNBTCTxRPC, {
+				await makeReq(postNBTCTxRPC, {
 					method: "postNBTCTx",
 					params: [network, txid!],
 				});
 				fetchMintTxs();
-				makeReq(utxosRPC, {
+				await makeReq(utxosRPC, {
 					method: "queryUTXOs",
 					params: [network, currentAddress.address],
 				});


### PR DESCRIPTION
## Description

Closes: #XXXX

---

### Author Checklist

All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.\_

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  - `fix`: A bug fix
  - `docs`: Documentation only changes
  - `style`: Changes that do not affect the meaning of the code (formatting, missing semi-colons, etc)
  - `refactor`: A code change that neither fixes a bug nor adds a feature
  - `perf`: A code change that improves performance
  - `test`: Adding missing tests or correcting existing tests
  - `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  - `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  - `chore`: Other changes that don't modify src or test files
  - `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Await RPC calls for posting mint transaction and querying UTXOs before updating the UI to ensure data consistency

Bug Fixes:
- Await postNBTCTx RPC call before invoking fetchMintTxs to ensure the mint transaction is confirmed before reload
- Await UTXOs query RPC call before proceeding to update UTXO state for accurate balance display