### PR TITLE
feat: use domain address for bitcoin devnet

### DIFF
--- a/app/config/bitcoin/contracts-config.ts
+++ b/app/config/bitcoin/contracts-config.ts
@@ -30,18 +30,18 @@ export const mainnetCfg: BitcoinConfig = {
 	btcRPCUrl: "",
 };
 
-export const regtestCfg: BitcoinConfig = {
-	bitcoinBroadcastLink: "http://142.93.46.134:3002/tx/",
+export const devnetCfg: BitcoinConfig = {
+	bitcoinBroadcastLink: "http://bitcoin-devnet.gonative.cc:3002/tx/",
 	confirmationDepth: 4,
 	blockTimeSec: 120,
-	mempoolApiUrl: "http://142.93.46.134:3002",
+	mempoolApiUrl: "http://bitcoin-devnet.gonative.cc:3002",
 	minerFeeSats: 1000,
 	nBTC: {
 		depositAddress: "bcrt1q90xm34jqm0kcpfclkdmn868rw6vcv9fzvfg6p6",
 		mintingFee: 10,
 	},
 	indexerUrl: "https://btcindexer.gonative-cc.workers.dev:443",
-	btcRPCUrl: "http://142.93.46.134:3002",
+	btcRPCUrl: "http://bitcoin-devnet.gonative.cc:3002",
 };
 
 export const bitcoinConfigs: Record<BitcoinNetworkType, BitcoinConfig | undefined> = {
@@ -49,5 +49,5 @@ export const bitcoinConfigs: Record<BitcoinNetworkType, BitcoinConfig | undefine
 	Testnet: undefined,
 	Testnet4: undefined,
 	Signet: undefined,
-	Regtest: regtestCfg,
+	Regtest: devnetCfg,
 };

--- a/app/pages/Mint/RegtestInstructions.tsx
+++ b/app/pages/Mint/RegtestInstructions.tsx
@@ -52,7 +52,7 @@ export function RegtestInstructions() {
 				</li>
 				<li>
 					<strong>Add BTC URL:</strong> In the field labeled <strong>BTC URL</strong>, paste the
-					following address: <code>http://142.93.46.134:3002</code>
+					following address: <code>http://bitcoin-devnet.gonative.cc:3002</code>
 				</li>
 				<li>
 					<strong>Save:</strong> Press <strong>Save.</strong>


### PR DESCRIPTION
## Description

- use domain address to connect with our bitcoin node
- technically, this also allows to query RPC directly and bypassing byiled proxy.

## Summary by Sourcery

Use a domain address for Bitcoin devnet connections by updating the configuration and user instructions to point to bitcoin-devnet.gonative.cc instead of the previous IP.

New Features:
- Replace hardcoded IP endpoints with the bitcoin-devnet.gonative.cc domain for RPC, mempool, and broadcast links in the devnet configuration

Enhancements:
- Rename regtestCfg to devnetCfg and map it under the Regtest network type

Documentation:
- Update the RegtestInstructions UI to reference the new domain address instead of the IP