### PR TITLE
refactor: update defaultSuiNetwork clousure

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -78,17 +78,8 @@ function NativeApp({ children }: { children: React.ReactNode }) {
 	const location = useLocation();
 	const pathname = location.pathname;
 
-	// Default network based on environment and route - but allow wallet to override
-	const defaultNetwork = (() => {
-		if (isProductionMode()) {
-			if (pathname === "/beelievers-auction") {
-				return "mainnet";
-			}
-			return "testnet";
-		}
-		// default to testnet (localnet still available via wallet switching)
-		return "testnet";
-	})();
+	const defaultSuiNet: "testnet" | "mainnet" =
+		isProductionMode() && pathname === "/beelievers-auction" ? "mainnet" : "testnet";
 
 	useEffect(() => {
 		if (!isProductionMode()) {
@@ -100,7 +91,7 @@ function NativeApp({ children }: { children: React.ReactNode }) {
 		<>
 			<div className="flex min-h-screen w-full flex-col gap-4">
 				<QueryClientProvider client={queryClient}>
-					<SuiClientProvider networks={networkConfig} defaultNetwork={defaultNetwork}>
+					<SuiClientProvider networks={networkConfig} defaultNetwork={defaultSuiNet}>
 						<SuiWalletProvider autoConnect>
 							<ByieldWalletProvider>
 								<main className="flex-1">{children}</main>


### PR DESCRIPTION
## Description

Closes: #XXXX

---

### Author Checklist

All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.\_

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  - `fix`: A bug fix
  - `docs`: Documentation only changes
  - `style`: Changes that do not affect the meaning of the code (formatting, missing semi-colons, etc)
  - `refactor`: A code change that neither fixes a bug nor adds a feature
  - `perf`: A code change that improves performance
  - `test`: Adding missing tests or correcting existing tests
  - `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  - `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  - `chore`: Other changes that don't modify src or test files
  - `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Simplify the default Sui network selection logic in the root component by replacing the IIFE with a single ternary and updating its variable name and usage

Enhancements:
- Refactor default network determination to a concise ternary expression
- Rename defaultNetwork variable and prop to defaultSuiNet for clarity