### PR TITLE
style: update UI theme for primary color

### DIFF
--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -15,7 +15,7 @@
   --color-azure-20: rgba(12, 17, 29, 1);
   --color-azure-25: rgba(18, 25, 42, 1);
 
-  /* TODO: --bacground is not defiend, but it's used in other classes (eg: .from-background).
+  /* TODO: --background is not defiend, but it's used in other classes (eg: .from-background).
      Let's define it here */
   --color-background: hsl(var(--background));
   --color-foreground: oklch(0.982 0 0);


### PR DESCRIPTION
## Description


I have created `color-primary-foreground: oklch(0.722 0.1613 53.85);` color that should be used for headers rather than `color-primary` which should be used as a background for objects. See #578 for more details.

---

### Author Checklist

All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.\_

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  - `fix`: A bug fix
  - `docs`: Documentation only changes
  - `style`: Changes that do not affect the meaning of the code (formatting, missing semi-colons, etc)
  - `refactor`: A code change that neither fixes a bug nor adds a feature
  - `perf`: A code change that improves performance
  - `test`: Adding missing tests or correcting existing tests
  - `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  - `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  - `chore`: Other changes that don't modify src or test files
  - `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Update the dark theme color palette by defining missing background variables and migrating key color variables to the Oklch model

Enhancements:
- Define the --color-background CSS variable and add TODOs for missing definitions
- Switch --color-foreground, --color-primary-foreground, and --color-muted-foreground to Oklch color values
- Reposition and update --color-primary and --color-primary-content to use base-content for primary text