### PR TITLE
deps: bump bun

### DIFF
--- a/.github/workflows/js.yaml
+++ b/.github/workflows/js.yaml
@@ -22,6 +22,7 @@ jobs:
 
       # @v2
       - uses: oven-sh/setup-bun@635640504f6d7197d3bb29876a652f671028dc97
+
       - run: bun ci
 
       - name: lint

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"license": "MPL-2.0",
 	"private": true,
 	"type": "module",
-	"packageManager": "bun@1.2.20",
+	"packageManager": "bun@1.3.1",
 	"scripts": {
 		"prepare": "cd .git/hooks; ln -s -f ../../contrib/git-hooks/pre-commit ./",
 		"cf-typegen": "wrangler types",


### PR DESCRIPTION
## Description

Closes: #608

## Summary by Sourcery

Upgrade bun package manager to v1.3.1 and adjust the JavaScript CI workflow formatting

Enhancements:
- Bump bun from v1.2.20 to v1.3.1 in package.json

CI:
- Insert spacing after the setup-bun step in the GitHub Actions JS workflow