### PR TITLE
feat: move confimations from alert to tooltip

### DIFF
--- a/app/pages/nbtc-mint/ExpandableTransactionDetails.tsx
+++ b/app/pages/nbtc-mint/ExpandableTransactionDetails.tsx
@@ -16,7 +16,7 @@ function PostConfirmationFailureAlert() {
 	return (
 		<div className={`${infoBoxClasses()} space-y-3`}>
 			<div className="flex items-start gap-3">
-				<XCircle size={16} className="text-primary mt-0.5 flex-shrink-0" />
+				<XCircle size={16} className="text-primary mt-0.5 shrink-0" />
 				<div className="flex-1 space-y-3">
 					<div className="text-primary font-medium">
 						Transaction Failed - Manual Resolution Required
@@ -73,7 +73,7 @@ function SimpleErrorAlert({ title, message }: { title: string; message: string }
 	return (
 		<div className={infoBoxClasses()}>
 			<div className="flex items-start gap-3">
-				<XCircle size={16} className="text-primary mt-0.5 flex-shrink-0" />
+				<XCircle size={16} className="text-primary mt-0.5 shrink-0" />
 				<div className="space-y-3">
 					<div>
 						<div className="text-primary mb-1 font-medium">{title}</div>
@@ -195,9 +195,9 @@ export function ExpandableTransactionDetails({ transaction }: ExpandableTransact
 
 				<div className="flex items-center gap-2 text-sm">
 					{isFailed && transaction.numberOfConfirmation === 0 ? (
-						<XCircle size={16} className="text-error flex-shrink-0" />
+						<XCircle size={16} className="text-error shrink-0" />
 					) : isBroadcasted ? (
-						<CheckCircle size={16} className="text-success flex-shrink-0" />
+						<CheckCircle size={16} className="text-success shrink-0" />
 					) : (
 						<AnimatedHourglass size="md" />
 					)}
@@ -222,7 +222,7 @@ export function ExpandableTransactionDetails({ transaction }: ExpandableTransact
 
 				<div className="flex items-center gap-2 text-sm">
 					{isFailed && transaction.numberOfConfirmation === 0 ? null : isConfirmed ? (
-						<CheckCircle size={16} className="text-success flex-shrink-0" />
+						<CheckCircle size={16} className="text-success shrink-0" />
 					) : transaction.numberOfConfirmation > 0 ? (
 						<AnimatedHourglass size="md" />
 					) : null}
@@ -238,14 +238,14 @@ export function ExpandableTransactionDetails({ transaction }: ExpandableTransact
 							[{formatTimeRemaining(estimatedTimeRemaining())}]
 						</span>
 					)}
-					<ConfirmationsTooltip />
+					<ConfirmationsTooltip blockTime={blockTime} />
 				</div>
 
 				<div className="flex items-center gap-2 text-sm">
 					{isMinted ? (
-						<CheckCircle size={16} className="text-success flex-shrink-0" />
+						<CheckCircle size={16} className="text-success shrink-0" />
 					) : isFailed ? (
-						<XCircle size={16} className="text-error flex-shrink-0" />
+						<XCircle size={16} className="text-error shrink-0" />
 					) : isConfirmed ? (
 						<AnimatedHourglass size="md" />
 					) : null}
@@ -274,9 +274,11 @@ export function ExpandableTransactionDetails({ transaction }: ExpandableTransact
 	);
 }
 
-function ConfirmationsTooltip() {
+function ConfirmationsTooltip({ blockTime }: { blockTime: number }) {
 	return (
-		<Tooltip tooltip="Bitcoin requires confirmations to ensure that a transaction is final and irreversible, preventing double-spending. Confirmation is a Bitcoin Block minted after that transaction. 1 bitcoin block takes about {blockTime / 60} minutes.">
+		<Tooltip
+			tooltip={`Bitcoin requires confirmations to ensure that a transaction is final and irreversible, preventing double-spending. Confirmation is a Bitcoin Block minted after that transaction. 1 bitcoin block takes about ${blockTime / 60} minutes.`}
+		>
 			<Info size="1em" className="text-primary-foreground hover:text-primary ml-1 transition-colors" />
 		</Tooltip>
 	);


### PR DESCRIPTION
## Description

Needs to be tested

## Summary by Sourcery

Replace the inline alert for Bitcoin confirmations with a tooltip-based Info icon by introducing a new ConfirmationsTooltip component.

New Features:
- Add ConfirmationsTooltip component to encapsulate and display transaction confirmation details in a tooltip instead of a static alert.

Enhancements:
- Remove the old alert block and use the ConfirmationsTooltip in the transaction details view.