### PR TITLE
fix: buffer issue in mint nbtc

### DIFF
--- a/app/lib/btcindexer.client.ts
+++ b/app/lib/btcindexer.client.ts
@@ -1,0 +1,1 @@
+export const BTCIndexerLib: typeof import("@gonative-cc/btcindexer/models") | null = null;

--- a/app/pages/nbtc-mint/ExpandableTransactionDetails.tsx
+++ b/app/pages/nbtc-mint/ExpandableTransactionDetails.tsx
@@ -1,6 +1,4 @@
 import { Info, CheckCircle, XCircle } from "lucide-react";
-import { MintTxStatus } from "@gonative-cc/btcindexer/models";
-
 import { type MintTransaction } from "~/server/nbtc/types";
 import { AnimatedHourglass } from "~/components/ui/AnimatedHourglass";
 import { Tooltip } from "~/components/ui/tooltip";
@@ -8,6 +6,7 @@ import { useBitcoinConfig } from "~/hooks/useBitcoinConfig";
 import { NumericFormat } from "react-number-format";
 import { formatBTC } from "~/lib/denoms";
 import { infoBoxClasses } from "~/util/tailwind";
+import { BTCIndexerLib } from "~/lib/btcindexer.client";
 
 interface FailedTransactionAlertProps {
 	transaction: MintTransaction;
@@ -97,13 +96,14 @@ function SimpleErrorAlert({ title, message }: { title: string; message: string }
 function FailedTransactionAlert({ transaction }: FailedTransactionAlertProps) {
 	const isPostConfirmationFailure =
 		transaction.numberOfConfirmation >= 4 &&
-		transaction.status === MintTxStatus.MintFailed &&
+		transaction.status === BTCIndexerLib?.MintTxStatus.MintFailed &&
 		!transaction.suiTxId;
 
 	const isBroadcastFailure =
-		transaction.numberOfConfirmation === 0 && transaction.status === MintTxStatus.MintFailed;
+		transaction.numberOfConfirmation === 0 &&
+		transaction.status === BTCIndexerLib?.MintTxStatus.MintFailed;
 
-	const isReorgFailure = transaction.status === MintTxStatus.Reorg;
+	const isReorgFailure = transaction.status === BTCIndexerLib?.MintTxStatus.Reorg;
 
 	if (isPostConfirmationFailure) {
 		return <PostConfirmationFailureAlert />;
@@ -159,8 +159,8 @@ export function ExpandableTransactionDetails({ transaction }: ExpandableTransact
 
 	const estimatedTimeRemaining = () => {
 		if (
-			transaction.status !== MintTxStatus.Confirming &&
-			transaction.status !== MintTxStatus.Broadcasting
+			transaction.status !== BTCIndexerLib?.MintTxStatus.Confirming &&
+			transaction.status !== BTCIndexerLib?.MintTxStatus.Broadcasting
 		)
 			return null;
 		const remainingConfirmations = Math.max(0, confirmationDepth - transaction.numberOfConfirmation);
@@ -174,15 +174,16 @@ export function ExpandableTransactionDetails({ transaction }: ExpandableTransact
 		return `~${minutes} minutes`;
 	};
 
-	const isBroadcasted = transaction.status !== MintTxStatus.Broadcasting;
+	const isBroadcasted = transaction.status !== BTCIndexerLib?.MintTxStatus.Broadcasting;
 	const isConfirmed = transaction.numberOfConfirmation >= confirmationDepth;
-	const isMinted = transaction.status === MintTxStatus.Minted;
+	const isMinted = transaction.status === BTCIndexerLib?.MintTxStatus.Minted;
 	const isFailed =
-		transaction.status === MintTxStatus.MintFailed || transaction.status === MintTxStatus.Reorg;
+		transaction.status === BTCIndexerLib?.MintTxStatus.MintFailed ||
+		transaction.status === BTCIndexerLib?.MintTxStatus.Reorg;
 	const showTimeRemaining =
 		!isConfirmed &&
-		(transaction.status === MintTxStatus.Confirming ||
-			transaction.status === MintTxStatus.Broadcasting) &&
+		(transaction.status === BTCIndexerLib?.MintTxStatus.Confirming ||
+			transaction.status === BTCIndexerLib?.MintTxStatus.Broadcasting) &&
 		estimatedTimeRemaining();
 
 	return (

--- a/app/pages/nbtc-mint/MintBTCTable.tsx
+++ b/app/pages/nbtc-mint/MintBTCTable.tsx
@@ -1,6 +1,4 @@
 import type { CellProps, Column, Row } from "react-table";
-import { MintTxStatus } from "@gonative-cc/btcindexer/models";
-
 import { Table } from "~/components/ui/table";
 import { Tooltip } from "~/components/ui/tooltip";
 import { trimAddress } from "~/components/Wallet/walletHelper";
@@ -12,6 +10,7 @@ import { ExpandableTransactionDetails } from "~/pages/nbtc-mint/ExpandableTransa
 import { AnimatedHourglass } from "~/components/ui/AnimatedHourglass";
 import { useState, useMemo, useCallback } from "react";
 import { useNetworkVariable } from "~/networkConfig";
+import { BTCIndexerLib } from "~/lib/btcindexer.client";
 
 function MintTableTooltip({ tooltip, label }: { tooltip: string; label: string }) {
 	return (
@@ -34,9 +33,9 @@ function buildSuiTransactionUrl(txId: string, explorerUrl?: string, configExplor
 	return `https://testnet.suivision.xyz/txblock/${txId}`;
 }
 
-const getStatusDisplay = (status: MintTxStatus) => {
+const getStatusDisplay = (status: import("@gonative-cc/btcindexer/models").MintTxStatus) => {
 	// TODO: handle reorg case - we need to inform a user when BTC was reorg and his deposit was not confirmed
-	const isActive = status != MintTxStatus.Minted;
+	const isActive = status != BTCIndexerLib?.MintTxStatus.Minted;
 	return (
 		<div className="flex items-center gap-2">
 			{isActive && <AnimatedHourglass size="md" />}

--- a/app/server/nbtc/convert.ts
+++ b/app/server/nbtc/convert.ts
@@ -1,5 +1,3 @@
-import type { MintTxStatus } from "@gonative-cc/btcindexer/models";
-
 import type { MintTransaction } from "./types";
 import { isProductionMode } from "~/lib/appenv";
 import { mainnetCfg, testnetCfg } from "~/config/sui/contracts-config";
@@ -16,7 +14,7 @@ export function nbtcMintTxRespToMintTx(tx: NbtcTxResp): MintTransaction {
 	return {
 		bitcoinTxId: tx.btc_tx_id,
 		amountInSatoshi: tx.amount_sats,
-		status: tx.status as MintTxStatus,
+		status: tx.status,
 		suiAddress: tx.sui_recipient,
 		suiTxId: tx.sui_tx_id || undefined,
 		timestamp: new Date(tx.created_at).getTime(),


### PR DESCRIPTION
## Description

Closes: #677 

---

### Author Checklist

All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.\_

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  - `fix`: A bug fix
  - `docs`: Documentation only changes
  - `style`: Changes that do not affect the meaning of the code (formatting, missing semi-colons, etc)
  - `refactor`: A code change that neither fixes a bug nor adds a feature
  - `perf`: A code change that improves performance
  - `test`: Adding missing tests or correcting existing tests
  - `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  - `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  - `chore`: Other changes that don't modify src or test files
  - `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Abstract MintTxStatus references behind a client-only BTCIndexerLib stub to prevent Buffer-related SSR bundling errors and update mint nbtc components and conversion logic to use the dynamic status enum.

Bug Fixes:
- Prevent server-side Buffer issues by removing direct imports of @gonative-cc/btcindexer models and using a client-only wrapper.

Enhancements:
- Add app/lib/btcindexer.client.ts as a stub for dynamic BTCIndexerLib import.
- Update ExpandableTransactionDetails and MintBTCTable to reference MintTxStatus via BTCIndexerLib with optional chaining.
- Simplify server conversion by assigning transaction status directly without casting.