### PR TITLE
feat: feedback from joao

### DIFF
--- a/app/pages/Hive/ControlledHiveTabs.tsx
+++ b/app/pages/Hive/ControlledHiveTabs.tsx
@@ -32,7 +32,7 @@ export const ControlledHiveTabs = () => {
 	};
 
 	return (
-		<div className="w-full">
+		<div className="w-full max-w-7xl">
 			<div className="mb-12 flex justify-center">
 				<div className="tabs tabs-boxed bg-base-200 rounded-full shadow-lg">
 					{renderTabButton("home")}

--- a/app/pages/Hive/Home.tsx
+++ b/app/pages/Hive/Home.tsx
@@ -98,8 +98,8 @@ const MULTIPLIER_RULES: MultiplierRule[] = [
 			{
 				id: "early_bee",
 				label: "Early Bee",
-				value: "+20%",
-				description: "First 2,000 eligible wallets.",
+				value: "+5%",
+				description: "First 1,000 eligible wallets.",
 			},
 		],
 	},
@@ -111,11 +111,16 @@ const MULTIPLIER_RULES: MultiplierRule[] = [
 		items: [
 			{
 				id: "nft_normal",
-				label: "Standard Holder",
-				value: "+15%",
+				label: "Beelievers Normal NFT Holder",
+				value: "+5%",
 				description: "Hold a Beeliever NFT",
 			},
-			{ id: "nft_mythic", label: "Mythic Holder", value: "+30%", description: "Hold a Mythic NFT" },
+			{
+				id: "nft_mythic",
+				label: "Beelievers Mythic NFT Holder",
+				value: "+10%",
+				description: "Hold a Mythic NFT",
+			},
 		],
 	},
 	{
@@ -124,9 +129,9 @@ const MULTIPLIER_RULES: MultiplierRule[] = [
 		badgeColor: "badge-info",
 		description: "Based on the quantity of NFTs held. These do not stack (highest takes priority).",
 		items: [
-			{ id: "qty_5", label: "Hive 5", value: "+5%", description: "Hold ≥ 5 NFTs" },
-			{ id: "qty_10", label: "Hive 10", value: "+10%", description: "Hold ≥ 10 NFTs" },
-			{ id: "qty_20", label: "Hive 20", value: "+15%", description: "Hold ≥ 20 NFTs" },
+			{ id: "qty_5", label: "Hive 5", value: "+5%", description: "Holding ≥ 5 Beelievers NFTs" },
+			{ id: "qty_10", label: "Hive 10", value: "+8%", description: "Holding ≥ 10 Beelievers NFTs" },
+			{ id: "qty_20", label: "Hive 20", value: "+10%", description: "Holding ≥ 20 Beelievers NFTs" },
 		],
 	},
 ];
@@ -193,9 +198,9 @@ function GlobalMultipliersSection() {
 							key={group.title}
 							title={
 								<div className="flex items-center gap-3">
-									<h3 className="text-lg font-semibold">{group.title}</h3>
+									<h3 className="text-sm font-semibold md:text-lg">{group.title}</h3>
 									<span
-										className={`badge badge-outline badge-sm uppercase ${group.badgeColor}`}
+										className={`badge badge-outline badge-xs md:badge-sm uppercase ${group.badgeColor}`}
 									>
 										{group.badge}
 									</span>


### PR DESCRIPTION
## Description

Closes: #755 

---

### Author Checklist

All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.\_

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  - `fix`: A bug fix
  - `docs`: Documentation only changes
  - `style`: Changes that do not affect the meaning of the code (formatting, missing semi-colons, etc)
  - `refactor`: A code change that neither fixes a bug nor adds a feature
  - `perf`: A code change that improves performance
  - `test`: Adding missing tests or correcting existing tests
  - `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  - `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  - `chore`: Other changes that don't modify src or test files
  - `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Adjust Hive rewards multipliers and layout for updated Beelievers NFT program details.

Bug Fixes:
- Update Early Bee, standard, mythic, and quantity-based NFT multiplier values and labels to reflect the latest Beelievers reward structure.

Enhancements:
- Clarify multiplier descriptions to explicitly reference Beelievers NFTs and adjust copy for holding thresholds.
- Tighten Hive home multipliers header typography and badge sizing for better responsiveness across viewports.
- Constrain Hive tabs container width to a max content width for improved layout on large screens.